### PR TITLE
Update thread labels and savepoint names

### DIFF
--- a/crates/musq/src/musq.rs
+++ b/crates/musq/src/musq.rs
@@ -198,7 +198,7 @@ impl Musq {
             vfs: None,
             pragmas,
             serialized: false,
-            thread_name: Arc::new(DebugFn(|id| format!("sqlx-sqlite-worker-{id}"))),
+            thread_name: Arc::new(DebugFn(|id| format!("musq-worker-{id}"))),
             command_channel_size: 50,
             row_channel_size: 50,
             optimize_on_close: OptimizeOnClose::Disabled,

--- a/crates/musq/src/transaction.rs
+++ b/crates/musq/src/transaction.rs
@@ -86,17 +86,17 @@ impl<'c> Drop for Transaction<'c> {
 
 pub fn begin_ansi_transaction_sql(depth: usize) -> String {
     // The first savepoint is equivalent to a BEGIN
-    format!("SAVEPOINT _sqlx_savepoint_{depth}")
+    format!("SAVEPOINT _musq_savepoint_{depth}")
 }
 
 pub fn commit_ansi_transaction_sql(depth: usize) -> String {
-    format!("RELEASE SAVEPOINT _sqlx_savepoint_{}", depth - 1)
+    format!("RELEASE SAVEPOINT _musq_savepoint_{}", depth - 1)
 }
 
 pub fn rollback_ansi_transaction_sql(depth: usize) -> String {
     if depth == 1 {
         "ROLLBACK".into()
     } else {
-        format!("ROLLBACK TO SAVEPOINT _sqlx_savepoint_{}", depth - 1)
+        format!("ROLLBACK TO SAVEPOINT _musq_savepoint_{}", depth - 1)
     }
 }


### PR DESCRIPTION
## Summary
- rename the default worker thread label to `musq-worker-{id}`
- use `_musq_savepoint_*` for internal savepoints

## Testing
- `cargo test --all-targets --all-features` *(fails: `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_e_687b22bd84ac8333a7fe0cde866e4ed2