### PR TITLE
Remove outdated docs about PoolOptions

### DIFF
--- a/crates/musq/src/executor.rs
+++ b/crates/musq/src/executor.rs
@@ -120,8 +120,6 @@ pub trait Executor<'c>: Send + Debug + Sized {
     /// Prepare the SQL query, with parameter type information, to inspect the
     /// type information about its parameters and results.
     ///
-    /// Only some database drivers (PostgreSQL, MSSQL) can take advantage of
-    /// this extra information to influence parameter type inference.
     fn prepare_with<'e, 'q: 'e>(
         self,
         sql: &'q str,

--- a/crates/musq/src/pool/connection.rs
+++ b/crates/musq/src/pool/connection.rs
@@ -80,15 +80,13 @@ impl PoolConnection {
     /// Detach this connection from the pool, allowing it to open a replacement.
     ///
     /// Note that if your application uses a single shared pool, this
-    /// effectively lets the application exceed the [`max_connections`] setting.
+    /// effectively lets the application exceed the `max_connections` setting.
     ///
-    /// If [`min_connections`] is nonzero, a task will be spawned to replace this connection.
+    /// If `min_connections` is nonzero, a task will be spawned to replace this connection.
     ///
     /// If you want the pool to treat this connection as permanently checked-out,
     /// use [`.leak()`][Self::leak] instead.
     ///
-    /// [`max_connections`]: crate::pool::PoolOptions::max_connections
-    /// [`min_connections`]: crate::pool::PoolOptions::min_connections
     pub fn detach(mut self) -> Connection {
         self.take_live().float(self.pool.clone()).detach()
     }

--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -49,7 +49,8 @@ pub use self::maybe::MaybePoolConnection;
 /// The pool has a maximum connection limit that it will not exceed; if `acquire()` is called when at this limit and all
 /// connections are checked out, the task will be made to wait until a connection becomes available.
 ///
-/// You can configure the connection limit, and other parameters, using [PoolOptions][crate::pool::PoolOptions].
+/// You can configure the connection limit, and other parameters, using the
+/// [`Musq`](crate::Musq) configuration API.
 ///
 /// Calls to `acquire()` are fair, i.e. fulfilled on a first-come, first-serve basis.
 ///
@@ -91,7 +92,7 @@ impl Pool {
     /// Retrieves a connection from the pool.
     ///
     /// The total time this method is allowed to execute is capped by
-    /// [`PoolOptions::acquire_timeout`].
+    /// [`Musq::acquire_timeout`].
     /// If that timeout elapses, this will return [`Error::PoolClosed`].
     ///
     /// ### Note: Cancellation/Timeout May Drop Connections
@@ -103,11 +104,10 @@ impl Pool {
     ///
     /// However, if your workload is sensitive to dropped connections such as using an in-memory
     /// SQLite database with a pool size of 1, you can pretty easily ensure that a cancelled
-    /// `acquire()` call will never drop connections by tweaking your [`PoolOptions`]:
+    /// `acquire()` call will never drop connections by tweaking your [`Musq`] options:
     ///
-    /// * Set [`test_before_acquire(false)`][PoolOptions::test_before_acquire]
-    /// * Never set [`before_acquire`][PoolOptions::before_acquire] or
-    ///   [`after_connect`][PoolOptions::after_connect].
+    /// * Set `test_before_acquire(false)`
+    /// * Never set `before_acquire` or `after_connect`.
     ///
     /// This should eliminate any potential `.await` points between acquiring a connection and
     /// returning it.


### PR DESCRIPTION
## Summary
- drop comment about other database drivers
- switch PoolOptions references to new `Musq` builder API

## Testing
- `cargo check -q` *(fails: `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_e_687b22b0a658833396df136b7b169378