### PR TITLE
Switch to tokio sync primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,17 +642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-intrusive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,10 +1093,8 @@ dependencies = [
  "event-listener",
  "flume",
  "futures",
- "futures-channel",
  "futures-core",
  "futures-executor",
- "futures-intrusive",
  "futures-util",
  "hashlink",
  "hex",

--- a/crates/musq/Cargo.toml
+++ b/crates/musq/Cargo.toml
@@ -19,11 +19,6 @@ time = { version = "0.3.14", features = [
 bytes = "1.1.0"
 crossbeam-queue = "0.3.2"
 either = { version = "1.6.1", features = ["serde"] }
-futures-channel = { version = "0.3.19", default-features = false, features = [
-    "sink",
-    "alloc",
-    "std",
-] }
 futures-core = { version = "0.3.19", default-features = false }
 futures-util = { version = "0.3.19", default-features = false, features = [
     "alloc",
@@ -47,7 +42,6 @@ libsqlite3-sys = { version = "0.35", features = [
     "bundled",
     "unlock_notify",
 ] }
-futures-intrusive = "0.5.0"
 atoi = "2.0.0"
 
 [dev-dependencies]

--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -6,9 +6,9 @@ use std::{
 };
 
 use futures_core::future::BoxFuture;
-use futures_intrusive::sync::MutexGuard;
 use futures_util::future;
 use libsqlite3_sys::{sqlite3, sqlite3_progress_handler};
+use tokio::sync::MutexGuard;
 
 use crate::{
     Result,


### PR DESCRIPTION
## Summary
- replace `futures_channel` and `futures_intrusive` usage with `tokio::sync`
- update worker locking and rendezvous oneshot
- adapt async-stream helper to tokio's mpsc

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687b22fbe1c083338760551560d33ac9