### PR TITLE
Switch ArgumentValue to owned data

### DIFF
--- a/crates/musq-macros/src/json.rs
+++ b/crates/musq-macros/src/json.rs
@@ -26,7 +26,7 @@ pub fn expand_json(input: &DeriveInput) -> syn::Result<TokenStream> {
                          "failed to encode value as JSON; the most likely cause is \
                          attempting to serialize a map with a non-string key type"
                 );
-                musq::ArgumentValue::Text(std::sync::Arc::new(v))
+                musq::ArgumentValue::Text(v)
             }
         }
 

--- a/crates/musq/src/sqlite/arguments.rs
+++ b/crates/musq/src/sqlite/arguments.rs
@@ -3,13 +3,12 @@ use crate::{Error, encode::Encode, sqlite::statement::StatementHandle};
 use atoi::atoi;
 use libsqlite3_sys::SQLITE_OK;
 
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub enum ArgumentValue {
     Null,
-    Text(Arc<String>),
-    Blob(Arc<Vec<u8>>),
+    Text(String),
+    Blob(Vec<u8>),
     Double(f64),
     Int(i32),
     Int64(i64),
@@ -83,7 +82,7 @@ impl ArgumentValue {
 
         let status = match self {
             Text(v) => handle.bind_text(i, v.as_str()),
-            Blob(v) => handle.bind_blob(i, v),
+            Blob(v) => handle.bind_blob(i, v.as_slice()),
             Int(v) => handle.bind_int(i, *v),
             Int64(v) => handle.bind_int64(i, *v),
             Double(v) => handle.bind_double(i, *v),

--- a/crates/musq/src/types/bstr.rs
+++ b/crates/musq/src/types/bstr.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 /// Conversions between `bstr` types and SQL types.
 use crate::{
     ArgumentValue, Result, SqliteDataType, Value, compatible, decode::Decode, encode::Encode,
@@ -18,12 +16,12 @@ impl<'r> Decode<'r> for BString {
 
 impl Encode for &BStr {
     fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob(Arc::new(self.as_bytes().to_owned()))
+        ArgumentValue::Blob(self.as_bytes().to_owned())
     }
 }
 
 impl Encode for BString {
     fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob(Arc::new(self.as_bytes().to_vec()))
+        ArgumentValue::Blob(self.as_bytes().to_vec())
     }
 }

--- a/crates/musq/src/types/bytes.rs
+++ b/crates/musq/src/types/bytes.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl Encode for &[u8] {
     fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob(Arc::new(self.to_owned()))
+        ArgumentValue::Blob(self.to_owned())
     }
 }
 
@@ -20,7 +20,7 @@ impl<'r> Decode<'r> for &'r [u8] {
 
 impl Encode for Vec<u8> {
     fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob(Arc::new(self))
+        ArgumentValue::Blob(self)
     }
 }
 
@@ -33,7 +33,7 @@ impl<'r> Decode<'r> for Vec<u8> {
 
 impl Encode for Arc<Vec<u8>> {
     fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob(self.clone())
+        ArgumentValue::Blob((*self).clone())
     }
 }
 

--- a/crates/musq/src/types/str.rs
+++ b/crates/musq/src/types/str.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl Encode for &str {
     fn encode(self) -> ArgumentValue {
-        ArgumentValue::Text(Arc::new(self.to_owned()))
+        ArgumentValue::Text(self.to_owned())
     }
 }
 
@@ -20,7 +20,7 @@ impl<'r> Decode<'r> for &'r str {
 
 impl Encode for String {
     fn encode(self) -> ArgumentValue {
-        ArgumentValue::Text(Arc::new(self))
+        ArgumentValue::Text(self)
     }
 }
 
@@ -33,7 +33,7 @@ impl<'r> Decode<'r> for String {
 
 impl Encode for Arc<String> {
     fn encode(self) -> ArgumentValue {
-        ArgumentValue::Text(self.clone())
+        ArgumentValue::Text((*self).clone())
     }
 }
 

--- a/crates/musq/src/types/time.rs
+++ b/crates/musq/src/types/time.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{
     Value, compatible,
     decode::Decode,
@@ -13,28 +11,28 @@ pub use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
 impl Encode for OffsetDateTime {
     fn encode(self) -> ArgumentValue {
-        ArgumentValue::Text(Arc::new(self.format(&Rfc3339).unwrap()))
+        ArgumentValue::Text(self.format(&Rfc3339).unwrap())
     }
 }
 
 impl Encode for PrimitiveDateTime {
     fn encode(self) -> ArgumentValue {
         let format = fd!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond]");
-        ArgumentValue::Text(Arc::new(self.format(&format).unwrap()))
+        ArgumentValue::Text(self.format(&format).unwrap())
     }
 }
 
 impl Encode for Date {
     fn encode(self) -> ArgumentValue {
         let format = fd!("[year]-[month]-[day]");
-        ArgumentValue::Text(Arc::new(self.format(&format).unwrap()))
+        ArgumentValue::Text(self.format(&format).unwrap())
     }
 }
 
 impl Encode for Time {
     fn encode(self) -> ArgumentValue {
         let format = fd!("[hour]:[minute]:[second].[subsecond]");
-        ArgumentValue::Text(Arc::new(self.format(&format).unwrap()))
+        ArgumentValue::Text(self.format(&format).unwrap())
     }
 }
 


### PR DESCRIPTION
## Summary
- update `ArgumentValue` to own `String` and `Vec<u8>`
- update all encoders to use the new owned variants
- adjust binding and derive macros accordingly

## Testing
- `cargo test -p musq --tests --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687b33f4c35483338f7f7ae1f0357e6d