### PR TITLE
Refactor SQLite value handling

### DIFF
--- a/crates/musq/src/sqlite/mod.rs
+++ b/crates/musq/src/sqlite/mod.rs
@@ -10,4 +10,4 @@ mod connection;
 pub mod error;
 pub mod statement;
 mod type_info;
-mod value;
+pub(crate) mod value;

--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -10,9 +10,10 @@ use libsqlite3_sys::{
     SQLITE_UTF8, sqlite3, sqlite3_bind_blob64, sqlite3_bind_double, sqlite3_bind_int,
     sqlite3_bind_int64, sqlite3_bind_null, sqlite3_bind_parameter_count,
     sqlite3_bind_parameter_name, sqlite3_bind_text64, sqlite3_changes, sqlite3_clear_bindings,
-    sqlite3_column_count, sqlite3_column_decltype, sqlite3_column_name, sqlite3_column_type,
-    sqlite3_column_value, sqlite3_db_handle, sqlite3_finalize, sqlite3_reset, sqlite3_step,
-    sqlite3_stmt, sqlite3_value,
+    sqlite3_column_blob, sqlite3_column_bytes, sqlite3_column_count, sqlite3_column_decltype,
+    sqlite3_column_double, sqlite3_column_int, sqlite3_column_int64, sqlite3_column_name,
+    sqlite3_column_type, sqlite3_column_value, sqlite3_db_handle, sqlite3_finalize, sqlite3_reset,
+    sqlite3_step, sqlite3_stmt, sqlite3_value,
 };
 
 use crate::sqlite::SqliteError;
@@ -160,6 +161,26 @@ impl StatementHandle {
 
     pub(crate) fn column_value(&self, index: usize) -> *mut sqlite3_value {
         unsafe { sqlite3_column_value(self.0.as_ptr(), index as c_int) }
+    }
+
+    pub(crate) fn column_int(&self, index: usize) -> i32 {
+        unsafe { sqlite3_column_int(self.0.as_ptr(), index as c_int) }
+    }
+
+    pub(crate) fn column_int64(&self, index: usize) -> i64 {
+        unsafe { sqlite3_column_int64(self.0.as_ptr(), index as c_int) }
+    }
+
+    pub(crate) fn column_double(&self, index: usize) -> f64 {
+        unsafe { sqlite3_column_double(self.0.as_ptr(), index as c_int) }
+    }
+
+    pub(crate) fn column_blob(&self, index: usize) -> *const c_void {
+        unsafe { sqlite3_column_blob(self.0.as_ptr(), index as c_int) }
+    }
+
+    pub(crate) fn column_bytes(&self, index: usize) -> i32 {
+        unsafe { sqlite3_column_bytes(self.0.as_ptr(), index as c_int) }
     }
 
     pub(crate) fn clear_bindings(&self) {


### PR DESCRIPTION
## Summary
- own SQLite values in Rust instead of referencing `sqlite3_value`
- read column values directly via `sqlite3_column_*` functions
- expose column accessors on `StatementHandle`
- adjust `Row` construction for owned values

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687b389c0fa48333b025c0213653cafc