### PR TITLE
Replace SQLx references

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ FIXME: Add note on efficiently querying large blobs
 
 ## Why?
 
-Musq is a SQLite-focused fork of sqlx. The aims are to simplify and clean up the codebase, strip out un-needed features and complexity, add new features, improve testing and ergonomics, and support WASM.
+Musq is a SQLite-focused fork of SQLx. The aims are to simplify and clean up the codebase, strip out un-needed features and complexity, add new features, improve testing and ergonomics, and support WASM.
 
 
 ## Profiling

--- a/crates/musq/src/error.rs
+++ b/crates/musq/src/error.rs
@@ -1,11 +1,11 @@
-//! Types for working with errors produced by SQLx.
+//! Types for working with errors produced by Musq.
 
 use std::io;
 use std::num::TryFromIntError;
 
 use crate::{SqliteDataType, sqlite, sqlite::error::SqliteError};
 
-/// A specialized `Result` type for SQLx.
+/// A specialized `Result` type for Musq.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(thiserror::Error, Debug)]
@@ -28,7 +28,7 @@ impl From<String> for DecodeError {
     }
 }
 
-/// Represents all the ways a method can fail within SQLx.
+/// Represents all the ways a method can fail within Musq.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
@@ -42,7 +42,7 @@ pub enum Error {
 
     /// Unexpected or invalid data encountered while communicating with the database.
     ///
-    /// This should indicate there is a programming error in a SQLx driver or there
+    /// This should indicate there is a programming error in Musq or there
     /// is something corrupted with the connection to the database itself.
     #[error("encountered unexpected or invalid data: {0}")]
     Protocol(String),

--- a/crates/musq/src/musq.rs
+++ b/crates/musq/src/musq.rs
@@ -225,7 +225,7 @@ impl Musq {
 
     /// Set the enforcement of [foreign key constraints](https://www.sqlite.org/pragma.html#pragma_foreign_keys).
     ///
-    /// SQLx chooses to enable this by default so that foreign keys function as expected,
+    /// Musq enables this by default so that foreign keys function as expected,
     /// compared to other database flavors.
     pub fn foreign_keys(self, on: bool) -> Self {
         self.pragma("foreign_keys", if on { "ON" } else { "OFF" })
@@ -252,13 +252,13 @@ impl Musq {
     /// You may get a `database is locked` (corresponding to `SQLITE_BUSY`) error if another
     /// connection is accessing the database file at the same time.
     ///
-    /// SQLx does not set a journal mode by default, to avoid unintentionally changing a database
+    /// Musq does not set a journal mode by default, to avoid unintentionally changing a database
     /// into or out of WAL mode.
     ///
     /// The default journal mode for non-WAL databases is `DELETE`, or `MEMORY` for in-memory
     /// databases.
     ///
-    /// For consistency, any commands in `sqlx-cli` which create a SQLite database will create it
+    /// For consistency, any commands in `musq-cli` which create a SQLite database will create it
     /// in WAL mode.
     pub fn journal_mode(self, mode: JournalMode) -> Self {
         self.pragma("journal_mode", mode.as_str())
@@ -363,7 +363,7 @@ impl Musq {
     ///
     /// If you do end up needing to set this to `true` for some reason, please
     /// [open an issue](https://github.com/launchbadge/sqlx/issues/new/choose) as this may indicate
-    /// a concurrency bug in SQLx. Please provide clear instructions for reproducing the issue,
+    /// a concurrency bug in Musq. Please provide clear instructions for reproducing the issue,
     /// including a sample database schema if applicable.
     pub fn serialized(mut self, serialized: bool) -> Self {
         self.serialized = serialized;

--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -31,7 +31,7 @@ mod worker;
 
 /// A connection to an open [Sqlite] database.
 ///
-/// Because SQLite is an in-process database accessed by blocking API calls, SQLx uses a background
+/// Because SQLite is an in-process database accessed by blocking API calls, Musq uses a background
 /// thread and communicates with it via channels to allow non-blocking access to the database.
 ///
 /// Dropping this struct will signal the worker thread to quit and close the database, though
@@ -252,7 +252,7 @@ impl LockedSqliteHandle<'_> {
     /// However, we reserve the right to upgrade `libsqlite3-sys` as necessary.
     ///
     /// Thus, if you are making direct calls via `libsqlite3-sys` you should pin the version
-    /// of SQLx that you're using, and upgrade it and `libsqlite3-sys` manually as new
+    /// of Musq that you're using, and upgrade it and `libsqlite3-sys` manually as new
     /// versions are released.
     pub fn as_raw_handle(&mut self) -> NonNull<sqlite3> {
         self.guard.handle.as_non_null_ptr()


### PR DESCRIPTION
## Summary
- replace mentions of SQLx with Musq in documentation comments
- clarify Musq defaults for foreign keys and journal mode
- update documentation around raw handle usage

## Testing
- `cargo test --workspace --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_687b969a1c64833385eedd3b540452c8