### PR TITLE
Add macro derive tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,8 +1147,11 @@ version = "0.0.1"
 dependencies = [
  "darling",
  "heck",
+ "musq",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "syn",
 ]
 

--- a/crates/musq-macros/Cargo.toml
+++ b/crates/musq-macros/Cargo.toml
@@ -17,3 +17,8 @@ heck = "0.5.0"
 proc-macro2 = "1.0.69"
 quote = "1.0.33"
 syn = "2.0.39"
+
+[dev-dependencies]
+musq = { path = "../musq" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/musq-macros/src/lib.rs
+++ b/crates/musq-macros/src/lib.rs
@@ -55,3 +55,6 @@ pub fn derive_from_row(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
         Err(e) => e.to_compile_error().into(),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/musq-macros/src/tests/decode.rs
+++ b/crates/musq-macros/src/tests/decode.rs
@@ -1,0 +1,36 @@
+use crate::decode::expand_derive_decode;
+use crate::core::assert_errors_with;
+use syn::parse_str;
+
+#[test]
+fn derive_enum() {
+    let input = parse_str("enum Foo { One, Two }").unwrap();
+    let tokens = expand_derive_decode(&input).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl < 'r > musq :: decode :: Decode < 'r > for Foo"));
+}
+
+#[test]
+fn derive_enum_with_repr() {
+    let input = parse_str("#[musq(repr = \"i32\")] enum Foo { One, Two }").unwrap();
+    let tokens = expand_derive_decode(&input).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl < 'r > musq :: decode :: Decode < 'r > for Foo"));
+    assert!(s.contains("as i32"));
+}
+
+#[test]
+fn derive_struct() {
+    let input = parse_str("struct Foo(i32);").unwrap();
+    let tokens = expand_derive_decode(&input).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl < 'r > musq :: decode :: Decode < 'r > for Foo"));
+    assert!(s.contains("map (Self)"));
+}
+
+#[test]
+fn error_on_named_struct() {
+    let input = parse_str("struct Foo { a: i32 }").unwrap();
+    let e = expand_derive_decode(&input);
+    assert_errors_with!(e, "structs must have exactly one unnamed field");
+}

--- a/crates/musq-macros/src/tests/encode.rs
+++ b/crates/musq-macros/src/tests/encode.rs
@@ -1,0 +1,37 @@
+use crate::encode::expand_derive_encode;
+use crate::core::assert_errors_with;
+
+use syn::parse_str;
+
+#[test]
+fn derive_enum() {
+    let input = parse_str("enum Foo { One, Two }").unwrap();
+    let tokens = expand_derive_encode(&input).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl musq :: encode :: Encode for Foo"));
+}
+
+#[test]
+fn derive_enum_with_repr() {
+    let input = parse_str("#[musq(repr = \"i32\")] enum Foo { One, Two }").unwrap();
+    let tokens = expand_derive_encode(&input).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl musq :: encode :: Encode for Foo"));
+    assert!(s.contains("as i32"));
+}
+
+#[test]
+fn derive_struct() {
+    let input = parse_str("struct Foo(i32);").unwrap();
+    let tokens = expand_derive_encode(&input).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl musq :: encode :: Encode for Foo"));
+    assert!(s.contains("self . 0"));
+}
+
+#[test]
+fn error_on_named_struct() {
+    let input = parse_str("struct Foo { a: i32 }").unwrap();
+    let e = expand_derive_encode(&input);
+    assert_errors_with!(e, "structs must have exactly one unnamed field");
+}

--- a/crates/musq-macros/src/tests/from_row.rs
+++ b/crates/musq-macros/src/tests/from_row.rs
@@ -1,0 +1,26 @@
+use crate::row::expand_derive_from_row;
+use crate::core::assert_errors_with;
+use syn::parse_str;
+
+#[test]
+fn derive_struct() {
+    let txt = "struct Foo { a: i32, b: String }";
+    let tokens = expand_derive_from_row(&parse_str(txt).unwrap()).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl < 'a > musq :: FromRow < 'a > for Foo"));
+}
+
+#[test]
+fn derive_tuple_struct() {
+    let txt = "struct Foo(i32, String);";
+    let tokens = expand_derive_from_row(&parse_str(txt).unwrap()).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl < 'a , R : musq :: Row > musq :: FromRow < 'a > for Foo"));
+}
+
+#[test]
+fn error_on_unit_struct() {
+    let txt = "struct Foo;";
+    let e = expand_derive_from_row(&parse_str(txt).unwrap());
+    assert_errors_with!(e, "Unsupported shape");
+}

--- a/crates/musq-macros/src/tests/json.rs
+++ b/crates/musq-macros/src/tests/json.rs
@@ -1,0 +1,11 @@
+use crate::json::expand_json;
+use syn::parse_str;
+
+#[test]
+fn derive_json_struct() {
+    let txt = "struct Foo { a: i32, b: String }";
+    let tokens = expand_json(&parse_str(txt).unwrap()).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl musq :: encode :: Encode for Foo"));
+    assert!(s.contains("impl < 'r > musq :: decode :: Decode < 'r > for Foo"));
+}

--- a/crates/musq-macros/src/tests/mod.rs
+++ b/crates/musq-macros/src/tests/mod.rs
@@ -1,0 +1,4 @@
+mod encode;
+mod decode;
+mod from_row;
+mod json;


### PR DESCRIPTION
## Summary
- add missing dev-dependencies for tests in musq-macros crate
- create dedicated test modules for Encode, Decode, FromRow and Json derives
- hook new tests from lib

## Testing
- `cargo test -p musq-macros --quiet`
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687b96798c608333bb3192b02b838440