### PR TITLE
Handle SQLITE_LOCKED from unlock_notify

### DIFF
--- a/crates/musq/src/error.rs
+++ b/crates/musq/src/error.rs
@@ -93,6 +93,11 @@ pub enum Error {
     /// A background worker has crashed.
     #[error("attempted to communicate with a crashed background worker")]
     WorkerCrashed,
+
+    /// [`sqlite3_unlock_notify`] kept returning `SQLITE_LOCKED` even after
+    /// resetting the blocking statement.
+    #[error("unlock_notify failed after multiple attempts")] 
+    UnlockNotify,
 }
 
 impl Error {

--- a/crates/musq/src/sqlite/connection/execute.rs
+++ b/crates/musq/src/sqlite/connection/execute.rs
@@ -114,7 +114,7 @@ impl Iterator for ExecuteIter<'_> {
 
                 Some(Ok(Either::Left(done)))
             }
-            Err(e) => Some(Err(e.into())),
+            Err(e) => Some(Err(e)),
         }
     }
 }

--- a/crates/musq/src/sqlite/connection/handle.rs
+++ b/crates/musq/src/sqlite/connection/handle.rs
@@ -68,7 +68,7 @@ impl ConnectionHandle {
 
                 match status {
                     SQLITE_OK => return Ok(()),
-                    SQLITE_LOCKED_SHAREDCACHE => unlock_notify::wait(self.as_ptr())?,
+                    SQLITE_LOCKED_SHAREDCACHE => unlock_notify::wait(self.as_ptr(), None)?,
                     _ => return Err(SqliteError::new(self.as_ptr()).into()),
                 }
             }


### PR DESCRIPTION
## Summary
- retry unlock_notify after resetting statement
- add UnlockNotify error variant
- update statement step and connection exec to use new error

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687ba2963c5c8333adf48d0c68a76ea6