### PR TITLE
Validate int helper conversions

### DIFF
--- a/crates/musq/src/sqlite/value.rs
+++ b/crates/musq/src/sqlite/value.rs
@@ -18,8 +18,8 @@ pub(crate) enum ValueData {
 }
 
 impl Value {
-    pub fn int(&self) -> i32 {
-        self.int64() as i32
+    pub fn int(&self) -> Result<i32, DecodeError> {
+        Ok(i32::try_from(self.int64())?)
     }
 
     pub fn int64(&self) -> i64 {

--- a/crates/musq/src/types/bool.rs
+++ b/crates/musq/src/types/bool.rs
@@ -18,6 +18,6 @@ impl<'r> Decode<'r> for bool {
             value,
             SqliteDataType::Bool | SqliteDataType::Int | SqliteDataType::Int64
         );
-        Ok(value.int() != 0)
+        Ok(value.int()? != 0)
     }
 }

--- a/crates/musq/src/types/int.rs
+++ b/crates/musq/src/types/int.rs
@@ -15,7 +15,8 @@ impl Encode for i8 {
 impl<'r> Decode<'r> for i8 {
     fn decode(value: &'r Value) -> Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
-        Ok(value.int().try_into()?)
+        let v: i32 = value.int()?;
+        Ok(v.try_into()?)
     }
 }
 
@@ -28,7 +29,8 @@ impl Encode for i16 {
 impl<'r> Decode<'r> for i16 {
     fn decode(value: &'r Value) -> Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
-        Ok(value.int().try_into()?)
+        let v: i32 = value.int()?;
+        Ok(v.try_into()?)
     }
 }
 
@@ -41,7 +43,7 @@ impl Encode for i32 {
 impl<'r> Decode<'r> for i32 {
     fn decode(value: &'r Value) -> Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
-        Ok(value.int())
+        Ok(value.int()?)
     }
 }
 

--- a/crates/musq/src/types/uint.rs
+++ b/crates/musq/src/types/uint.rs
@@ -15,7 +15,8 @@ impl Encode for u8 {
 impl<'r> Decode<'r> for u8 {
     fn decode(value: &'r Value) -> Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
-        Ok(value.int().try_into()?)
+        let v: i32 = value.int()?;
+        Ok(v.try_into()?)
     }
 }
 
@@ -28,7 +29,8 @@ impl Encode for u16 {
 impl<'r> Decode<'r> for u16 {
     fn decode(value: &'r Value) -> Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
-        Ok(value.int().try_into()?)
+        let v: i32 = value.int()?;
+        Ok(v.try_into()?)
     }
 }
 


### PR DESCRIPTION
## Summary
- validate `Value::int` range when casting from i64
- propagate overflow checking in `bool`, `int`, and `uint` decoders

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687ba6aedbac8333ad093f587e461d77