### PR TITLE
Fix unlock_notify callback pointer type

### DIFF
--- a/crates/musq/src/sqlite/statement/unlock_notify.rs
+++ b/crates/musq/src/sqlite/statement/unlock_notify.rs
@@ -68,11 +68,11 @@ pub unsafe fn wait(
 }
 
 unsafe extern "C" fn unlock_notify_cb(ptr: *mut *mut c_void, len: c_int) {
-    let ptr = ptr as *mut &Notify;
+    let ptr = ptr as *mut *mut Notify;
     let slice = unsafe { slice::from_raw_parts(ptr, len as usize) };
 
-    for notify in slice {
-        notify.fire();
+    for &notify_ptr in slice {
+        unsafe { (&*notify_ptr).fire() };
     }
 }
 


### PR DESCRIPTION
## Summary
- update the raw pointer cast in `unlock_notify_cb` to use `*mut *mut Notify`
- dereference each pointer to invoke `Notify::fire`

## Testing
- `cargo check`
- `cargo test --workspace --exclude musq-cli -q`

------
https://chatgpt.com/codex/tasks/task_e_687baa7391e48333a145f6e9dd028759