### PR TITLE
Error on missing bind parameter

### DIFF
--- a/crates/musq/src/sqlite/arguments.rs
+++ b/crates/musq/src/sqlite/arguments.rs
@@ -102,10 +102,11 @@ impl Arguments {
             };
 
             if n > self.values.len() {
-                // SQLite treats unbound variables as NULL we reproduce this here. If you are reading this and think
-                // this should be an error, open an issue and we can discuss configuring this somehow. Note that the
-                // query macros have a different way of enforcing argument arity.
-                break;
+                return Err(Error::Protocol(format!(
+                    "bind parameter index out of bounds: the len is {}, but the index is {}",
+                    self.values.len(),
+                    n
+                )));
             }
 
             self.values[n - 1].bind(handle, param_i)?;

--- a/crates/musq/tests/sqlite.rs
+++ b/crates/musq/tests/sqlite.rs
@@ -879,3 +879,27 @@ async fn it_binds_strings() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn it_fails_on_missing_bind() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+
+    let res = musq::query("select ?1, ?2, ?4")
+        .bind(10_i32)
+        .bind(11_i32)
+        .fetch_one(&mut conn)
+        .await;
+
+    assert!(res.is_err());
+
+    let err = res.err().unwrap();
+
+    match err {
+        Error::Protocol(msg) => {
+            assert!(msg.contains("index is 4"));
+        }
+        _ => panic!("expected protocol error, got {err:?}"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- error when a query references a bind index that has no argument
- add a test for this failure case

## Testing
- `cargo test --workspace -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_687baa8bcdfc8333be4e0446fad9a68d