### PR TITLE
Handle null column_name pointers

### DIFF
--- a/crates/musq/src/sqlite/statement/compound.rs
+++ b/crates/musq/src/sqlite/statement/compound.rs
@@ -97,7 +97,7 @@ impl CompoundStatement {
                     let mut column_names = HashMap::with_capacity(num);
 
                     for i in 0..num {
-                        let name: UStr = statement.column_name(i).to_owned().into();
+                        let name: UStr = statement.column_name(i)?.to_owned().into();
                         let type_info = statement
                             .column_decltype(i)
                             .unwrap_or_else(|| statement.column_type_info(i));

--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -55,13 +55,15 @@ impl StatementHandle {
         unsafe { sqlite3_changes(self.db_handle()) as u64 }
     }
 
-    pub(crate) fn column_name(&self, index: usize) -> &str {
+    pub(crate) fn column_name(&self, index: usize) -> Result<&str, SqliteError> {
         // https://sqlite.org/c3ref/column_name.html
         unsafe {
             let name = sqlite3_column_name(self.0.as_ptr(), index as c_int);
-            debug_assert!(!name.is_null());
+            if name.is_null() {
+                return Err(self.last_error());
+            }
 
-            from_utf8_unchecked(CStr::from_ptr(name).to_bytes())
+            Ok(from_utf8_unchecked(CStr::from_ptr(name).to_bytes()))
         }
     }
 


### PR DESCRIPTION
## Summary
- propagate errors from `sqlite3_column_name` when it returns NULL
- handle new error case when preparing columns

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687bab21b5e083339516638f143d6907