### PR TITLE
Centralize more SQLite FFI calls

### DIFF
--- a/crates/musq/src/sqlite/error.rs
+++ b/crates/musq/src/sqlite/error.rs
@@ -4,7 +4,8 @@ use std::fmt::{self, Display, Formatter};
 use std::os::raw::c_int;
 use std::str::from_utf8_unchecked;
 
-use libsqlite3_sys::{self, sqlite3, sqlite3_errmsg, sqlite3_extended_errcode};
+use libsqlite3_sys::{self, sqlite3};
+use crate::sqlite::ffi;
 
 // Error Codes And Messages
 // https://www.sqlite.org/c3ref/errcode.html
@@ -257,9 +258,9 @@ pub struct SqliteError {
 
 impl SqliteError {
     pub(crate) fn new(handle: *mut sqlite3) -> Self {
-        let code = unsafe { sqlite3_extended_errcode(handle) };
+        let code = ffi::extended_errcode(handle);
         let message = unsafe {
-            let msg = sqlite3_errmsg(handle);
+            let msg = ffi::errmsg(handle);
             debug_assert!(!msg.is_null());
             from_utf8_unchecked(CStr::from_ptr(msg).to_bytes())
         }

--- a/crates/musq/src/sqlite/ffi.rs
+++ b/crates/musq/src/sqlite/ffi.rs
@@ -3,10 +3,77 @@
 // the SQLite C API so that the rest of the codebase can remain safe.
 
 use std::ffi::c_void;
-use std::os::raw::{c_char, c_int};
+use std::os::raw::{c_char, c_int, c_uint};
 use std::ptr;
 
-use libsqlite3_sys::{self as ffi_sys, sqlite3, sqlite3_stmt};
+use libsqlite3_sys::{
+    self as ffi_sys,
+    sqlite3,
+    sqlite3_stmt,
+};
+
+/// Wrapper around [`sqlite3_open_v2`].
+pub(crate) fn open_v2(
+    filename: *const c_char,
+    handle: *mut *mut sqlite3,
+    flags: c_int,
+    vfs: *const c_char,
+) -> c_int {
+    unsafe { ffi_sys::sqlite3_open_v2(filename, handle, flags, vfs) }
+}
+
+/// Wrapper around [`sqlite3_extended_result_codes`].
+pub(crate) fn extended_result_codes(db: *mut sqlite3, onoff: c_int) -> c_int {
+    unsafe { ffi_sys::sqlite3_extended_result_codes(db, onoff) }
+}
+
+/// Wrapper around [`sqlite3_busy_timeout`].
+pub(crate) fn busy_timeout(db: *mut sqlite3, ms: c_int) -> c_int {
+    unsafe { ffi_sys::sqlite3_busy_timeout(db, ms) }
+}
+
+/// Wrapper around [`sqlite3_prepare_v3`].
+pub(crate) fn prepare_v3(
+    db: *mut sqlite3,
+    sql: *const c_char,
+    n_byte: c_int,
+    flags: c_uint,
+    stmt: *mut *mut sqlite3_stmt,
+    tail: *mut *const c_char,
+) -> c_int {
+    unsafe { ffi_sys::sqlite3_prepare_v3(db, sql, n_byte, flags, stmt, tail) }
+}
+
+/// Wrapper around [`sqlite3_progress_handler`].
+pub(crate) fn progress_handler(
+    db: *mut sqlite3,
+    num_ops: c_int,
+    callback: Option<unsafe extern "C" fn(*mut c_void) -> c_int>,
+    arg: *mut c_void,
+) {
+    unsafe {
+        ffi_sys::sqlite3_progress_handler(db, num_ops, callback, arg);
+    }
+}
+
+/// Wrapper around [`sqlite3_unlock_notify`].
+pub(crate) fn unlock_notify(
+    db: *mut sqlite3,
+    callback: Option<unsafe extern "C" fn(*mut *mut c_void, c_int)>,
+    arg: *mut c_void,
+) -> c_int {
+    unsafe { ffi_sys::sqlite3_unlock_notify(db, callback, arg) }
+}
+
+/// Wrapper around [`sqlite3_extended_errcode`].
+pub(crate) fn extended_errcode(db: *mut sqlite3) -> c_int {
+    unsafe { ffi_sys::sqlite3_extended_errcode(db) }
+}
+
+/// Wrapper around [`sqlite3_errmsg`].
+pub(crate) fn errmsg(db: *mut sqlite3) -> *const c_char {
+    unsafe { ffi_sys::sqlite3_errmsg(db) }
+}
 
 /// Wrapper around [`sqlite3_close`].
 pub(crate) fn close(db: *mut sqlite3) -> c_int {

--- a/crates/musq/src/sqlite/statement/compound.rs
+++ b/crates/musq/src/sqlite/statement/compound.rs
@@ -7,10 +7,8 @@ use std::{
 };
 
 use bytes::{Buf, Bytes};
-use libsqlite3_sys::{
-    SQLITE_LOCKED_SHAREDCACHE, SQLITE_OK, SQLITE_PREPARE_PERSISTENT, sqlite3, sqlite3_prepare_v3,
-    sqlite3_stmt,
-};
+use libsqlite3_sys::{SQLITE_LOCKED_SHAREDCACHE, SQLITE_OK, SQLITE_PREPARE_PERSISTENT, sqlite3, sqlite3_stmt};
+use crate::sqlite::ffi;
 
 use crate::{
     Column,
@@ -160,16 +158,14 @@ fn prepare_all(conn: *mut sqlite3, query: &mut Bytes) -> Result<Option<Statement
 
         // <https://www.sqlite.org/c3ref/prepare.html>
         loop {
-            let status = unsafe {
-                sqlite3_prepare_v3(
-                    conn,
-                    query_ptr,
-                    query_len,
-                    flags,
-                    &mut statement_handle,
-                    &mut tail,
-                )
-            };
+            let status = ffi::prepare_v3(
+                conn,
+                query_ptr,
+                query_len,
+                flags as u32,
+                &mut statement_handle,
+                &mut tail,
+            );
 
             match status {
                 SQLITE_OK => break,


### PR DESCRIPTION
## Summary
- move additional raw SQLite calls into `ffi.rs`
- update SQLite modules to use the new wrappers

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687c32beaef083339a84ddbafb0f6ad2