### PR TITLE
Make unlock_notify::wait safe

### DIFF
--- a/crates/musq/src/sqlite/connection/handle.rs
+++ b/crates/musq/src/sqlite/connection/handle.rs
@@ -1,12 +1,12 @@
 use std::{ffi::CString, ptr::NonNull};
 
-use libsqlite3_sys::{SQLITE_LOCKED_SHAREDCACHE, SQLITE_OK, sqlite3};
+use libsqlite3_sys::{sqlite3, SQLITE_LOCKED_SHAREDCACHE, SQLITE_OK};
 
 use crate::sqlite::ffi;
 
 use crate::{
+    sqlite::{statement::unlock_notify, SqliteError},
     Error,
-    sqlite::{SqliteError, statement::unlock_notify},
 };
 
 /// Managed handle to the raw SQLite3 database handle.
@@ -54,7 +54,7 @@ impl ConnectionHandle {
 
             match status {
                 SQLITE_OK => return Ok(()),
-                SQLITE_LOCKED_SHAREDCACHE => unsafe { unlock_notify::wait(self.as_ptr(), None)? },
+                SQLITE_LOCKED_SHAREDCACHE => unlock_notify::wait(self.as_ptr(), None)?,
                 _ => return Err(SqliteError::new(self.as_ptr()).into()),
             }
         }

--- a/crates/musq/src/sqlite/statement/compound.rs
+++ b/crates/musq/src/sqlite/statement/compound.rs
@@ -2,23 +2,25 @@ use std::{
     cmp,
     collections::HashMap,
     os::raw::c_char,
-    ptr::{NonNull, null, null_mut},
+    ptr::{null, null_mut, NonNull},
     sync::Arc,
 };
 
-use bytes::{Buf, Bytes};
-use libsqlite3_sys::{SQLITE_LOCKED_SHAREDCACHE, SQLITE_OK, SQLITE_PREPARE_PERSISTENT, sqlite3, sqlite3_stmt};
 use crate::sqlite::ffi;
+use bytes::{Buf, Bytes};
+use libsqlite3_sys::{
+    sqlite3, sqlite3_stmt, SQLITE_LOCKED_SHAREDCACHE, SQLITE_OK, SQLITE_PREPARE_PERSISTENT,
+};
 
 use crate::{
-    Column,
     error::Error,
     sqlite::{
-        SqliteError,
         connection::ConnectionHandle,
-        statement::{StatementHandle, unlock_notify},
+        statement::{unlock_notify, StatementHandle},
+        SqliteError,
     },
     ustr::UStr,
+    Column,
 };
 
 // A compound statement consists of *zero* or more raw SQLite3 statements. We chop up a SQL statement
@@ -169,9 +171,9 @@ fn prepare_all(conn: *mut sqlite3, query: &mut Bytes) -> Result<Option<Statement
 
             match status {
                 SQLITE_OK => break,
-                SQLITE_LOCKED_SHAREDCACHE | libsqlite3_sys::SQLITE_BUSY => unsafe {
+                SQLITE_LOCKED_SHAREDCACHE | libsqlite3_sys::SQLITE_BUSY => {
                     unlock_notify::wait(conn, None)?;
-                },
+                }
                 _ => return Err(SqliteError::new(conn).into()),
             }
         }

--- a/crates/musq/src/sqlite/statement/unlock_notify.rs
+++ b/crates/musq/src/sqlite/statement/unlock_notify.rs
@@ -3,8 +3,8 @@ use std::os::raw::c_int;
 use std::slice;
 use std::sync::{Condvar, Mutex};
 
-use libsqlite3_sys::{SQLITE_LOCKED, SQLITE_OK, sqlite3, sqlite3_stmt};
 use crate::sqlite::ffi;
+use libsqlite3_sys::{sqlite3, sqlite3_stmt, SQLITE_LOCKED, SQLITE_OK};
 
 use crate::{
     error::Error,
@@ -16,7 +16,7 @@ const MAX_RETRIES: usize = 5;
 // Wait for unlock notification (https://www.sqlite.org/unlock_notify.html)
 // If `stmt` is provided, it will be reset and the call retried when
 // `SQLITE_LOCKED` is returned.
-pub unsafe fn wait(conn: *mut sqlite3, stmt: Option<*mut sqlite3_stmt>) -> Result<(), Error> {
+pub fn wait(conn: *mut sqlite3, stmt: Option<*mut sqlite3_stmt>) -> Result<(), Error> {
     let notify = Notify::new();
     let mut attempts = 0;
     loop {


### PR DESCRIPTION
## Summary
- make `unlock_notify::wait` a safe function
- remove unsafe blocks at call sites

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687c37a7c8488333b4b88cce02d9f626