### PR TITLE
Improve SQLite error handling

### DIFF
--- a/crates/musq/src/sqlite/arguments.rs
+++ b/crates/musq/src/sqlite/arguments.rs
@@ -2,7 +2,6 @@ use crate::{Error, encode::Encode, sqlite::statement::StatementHandle};
 use std::collections::HashMap;
 
 use atoi::atoi;
-use libsqlite3_sys::SQLITE_OK;
 
 #[derive(Debug)]
 pub enum ArgumentValue {
@@ -120,17 +119,13 @@ impl ArgumentValue {
     fn bind(&self, handle: &mut StatementHandle, i: usize) -> Result<(), Error> {
         use ArgumentValue::*;
 
-        let status = match self {
-            Text(v) => handle.bind_text(i, v.as_str()),
-            Blob(v) => handle.bind_blob(i, v.as_slice()),
-            Int(v) => handle.bind_int(i, *v),
-            Int64(v) => handle.bind_int64(i, *v),
-            Double(v) => handle.bind_double(i, *v),
-            Null => handle.bind_null(i),
-        };
-
-        if status != SQLITE_OK {
-            return Err(handle.last_error().into());
+        match self {
+            Text(v) => handle.bind_text(i, v.as_str())?,
+            Blob(v) => handle.bind_blob(i, v.as_slice())?,
+            Int(v) => handle.bind_int(i, *v)?,
+            Int64(v) => handle.bind_int64(i, *v)?,
+            Double(v) => handle.bind_double(i, *v)?,
+            Null => handle.bind_null(i)?,
         }
 
         Ok(())

--- a/crates/musq/src/sqlite/error.rs
+++ b/crates/musq/src/sqlite/error.rs
@@ -1,6 +1,4 @@
-use std::error::Error as StdError;
 use std::ffi::CStr;
-use std::fmt::{self, Display, Formatter};
 use std::os::raw::c_int;
 use std::str::from_utf8_unchecked;
 
@@ -249,7 +247,8 @@ impl ExtendedErrCode {
 }
 
 /// An error returned from Sqlite
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("(code: {:?}) {message}", .extended)]
 pub struct SqliteError {
     pub primary: PrimaryErrCode,
     pub extended: ExtendedErrCode,
@@ -274,14 +273,3 @@ impl SqliteError {
     }
 }
 
-impl Display for SqliteError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        // We include the code as some produce ambiguous messages:
-        // SQLITE_BUSY: "database is locked"
-        // SQLITE_LOCKED: "database table is locked"
-        // Sadly there's no function to get the string label back from an error code.
-        write!(f, "(code: {:?}) {}", self.extended, self.message)
-    }
-}
-
-impl StdError for SqliteError {}


### PR DESCRIPTION
## Summary
- derive `SqliteError` with `thiserror`
- turn SQLite FFI wrappers into `Result`-returning helpers
- propagate new errors through statement handling and connection logic

## Testing
- `cargo check -p musq`
- `cargo test -p musq --no-run`


------
https://chatgpt.com/codex/tasks/task_e_687c3a7d09788333a894b13516c56fa0