### PR TITLE
Remove IntoArguments abstraction

### DIFF
--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -34,7 +34,7 @@ pub use crate::{
     query_result::QueryResult,
     row::Row,
     sqlite::{
-        ArgumentValue, Arguments, Connection, IntoArguments, SqliteDataType, SqliteError,
+        ArgumentValue, Arguments, Connection, SqliteDataType, SqliteError,
         Statement, Value,
         error::{ExtendedErrCode, PrimaryErrCode},
     },

--- a/crates/musq/src/sqlite/arguments.rs
+++ b/crates/musq/src/sqlite/arguments.rs
@@ -20,12 +20,6 @@ pub struct Arguments {
     pub(crate) named: HashMap<String, usize>,
 }
 
-impl IntoArguments for Arguments {
-    fn into_arguments(self) -> Arguments {
-        self
-    }
-}
-
 impl Arguments {
     pub fn add<T>(&mut self, value: T)
     where
@@ -132,6 +126,3 @@ impl ArgumentValue {
     }
 }
 
-pub trait IntoArguments: Sized + Send {
-    fn into_arguments(self) -> Arguments;
-}

--- a/crates/musq/src/sqlite/mod.rs
+++ b/crates/musq/src/sqlite/mod.rs
@@ -1,4 +1,4 @@
-pub use arguments::{ArgumentValue, Arguments, IntoArguments};
+pub use arguments::{ArgumentValue, Arguments};
 pub use connection::Connection;
 pub use error::SqliteError;
 pub use statement::Statement;

--- a/crates/musq/src/sqlite/statement/mod.rs
+++ b/crates/musq/src/sqlite/statement/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::{Column, IntoArguments, from_row, query, sqlite::Arguments};
+use crate::{Column, from_row, query, sqlite::Arguments};
 
 mod compound;
 mod handle;
@@ -33,40 +33,36 @@ impl Statement {
         &self.columns
     }
 
-    pub fn query(&self) -> query::Query<Arguments> {
+    pub fn query(&self) -> query::Query {
         query::query_statement(self)
     }
 
-    pub fn query_with<A>(&self, arguments: A) -> query::Query<A>
-    where
-        A: IntoArguments,
-    {
+    pub fn query_with(&self, arguments: Arguments) -> query::Query {
         query::query_statement_with(self, arguments)
     }
 
     pub fn query_as<O>(
         &self,
-    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send, Arguments>
+    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send>
     where
         O: for<'r> from_row::FromRow<'r> + Send + Unpin,
     {
         query::query_statement_as(self)
     }
 
-    pub fn query_as_with<'s, O, A>(
+    pub fn query_as_with<'s, O>(
         &'s self,
-        arguments: A,
-    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send, A>
+        arguments: Arguments,
+    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send>
     where
         O: for<'r> from_row::FromRow<'r> + Send + Unpin,
-        A: IntoArguments,
     {
         query::query_statement_as_with(self, arguments)
     }
 
     pub fn query_scalar<O>(
         &self,
-    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send, Arguments>
+    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send>
     where
         (O,): for<'r> from_row::FromRow<'r>,
         O: Send + Unpin,
@@ -74,14 +70,13 @@ impl Statement {
         query::query_statement_scalar(self)
     }
 
-    pub fn query_scalar_with<'s, O, A>(
+    pub fn query_scalar_with<'s, O>(
         &'s self,
-        arguments: A,
-    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send, A>
+        arguments: Arguments,
+    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send>
     where
         (O,): for<'r> from_row::FromRow<'r>,
         O: Send + Unpin,
-        A: IntoArguments,
     {
         query::query_statement_scalar_with(self, arguments)
     }


### PR DESCRIPTION
## Summary
- drop `IntoArguments` trait and its impl
- update all query helpers and statement methods to use `Arguments` directly
- refactor `Query` and `Map` to drop generic argument type

## Testing
- `cargo test --workspace` *(fails: database table is locked)*

------
https://chatgpt.com/codex/tasks/task_e_687c405325588333988fa8c4cb67b67d