### PR TITLE
Use i32 in sqlite ffi

### DIFF
--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -1,14 +1,14 @@
 use std::{
     fmt::{self, Debug, Formatter, Write},
-    os::raw::{c_int, c_void},
+    os::raw::c_void,
     panic::catch_unwind,
     ptr::NonNull,
 };
 
+use crate::sqlite::ffi;
 use futures_core::future::BoxFuture;
 use futures_util::future;
 use libsqlite3_sys::sqlite3;
-use crate::sqlite::ffi;
 use tokio::sync::MutexGuard;
 
 use crate::{
@@ -229,7 +229,7 @@ impl Connection {
 
 /// Implements a C binding to a progress callback. The function returns `0` if the
 /// user-provided callback returns `true`, and `1` otherwise to signal an interrupt.
-extern "C" fn progress_callback<F>(callback: *mut c_void) -> c_int
+extern "C" fn progress_callback<F>(callback: *mut c_void) -> i32
 where
     F: FnMut() -> bool,
 {
@@ -238,7 +238,7 @@ where
             let callback: *mut F = callback.cast::<F>();
             (*callback)()
         });
-        c_int::from(!r.unwrap_or_default())
+        i32::from(!r.unwrap_or_default())
     }
 }
 

--- a/crates/musq/src/sqlite/error.rs
+++ b/crates/musq/src/sqlite/error.rs
@@ -1,9 +1,8 @@
 use std::ffi::CStr;
-use std::os::raw::c_int;
 use std::str::from_utf8_unchecked;
 
-use libsqlite3_sys::{self, sqlite3};
 use crate::sqlite::ffi;
+use libsqlite3_sys::{self, sqlite3};
 
 // Error Codes And Messages
 // https://www.sqlite.org/c3ref/errcode.html
@@ -43,7 +42,7 @@ pub enum PrimaryErrCode {
 }
 
 impl PrimaryErrCode {
-    fn from_code(code: c_int) -> PrimaryErrCode {
+    fn from_code(code: i32) -> PrimaryErrCode {
         match code & 255 {
             libsqlite3_sys::SQLITE_ERROR => PrimaryErrCode::Error,
             libsqlite3_sys::SQLITE_INTERNAL => PrimaryErrCode::Internal,
@@ -160,7 +159,7 @@ pub enum ExtendedErrCode {
 }
 
 impl ExtendedErrCode {
-    fn from_code(code: c_int) -> ExtendedErrCode {
+    fn from_code(code: i32) -> ExtendedErrCode {
         match code {
             libsqlite3_sys::SQLITE_ERROR_MISSING_COLLSEQ => ExtendedErrCode::ErrorMissingCollseq,
             libsqlite3_sys::SQLITE_ERROR_RETRY => ExtendedErrCode::ErrorRetry,
@@ -272,4 +271,3 @@ impl SqliteError {
         }
     }
 }
-

--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -1,15 +1,18 @@
-use std::ffi::c_void;
 use std::ffi::CStr;
+use std::ffi::c_void;
 
-use std::os::raw::{c_char, c_int};
+use std::os::raw::c_char;
 use std::ptr::NonNull;
 use std::str::from_utf8_unchecked;
 
 use libsqlite3_sys::{
-    sqlite3, sqlite3_stmt, SQLITE_DONE, SQLITE_LOCKED_SHAREDCACHE, SQLITE_MISUSE, SQLITE_ROW,
+    SQLITE_DONE, SQLITE_LOCKED_SHAREDCACHE, SQLITE_MISUSE, SQLITE_ROW, sqlite3, sqlite3_stmt,
 };
 
-use crate::sqlite::{ffi, error::{SqliteError, PrimaryErrCode}};
+use crate::sqlite::{
+    error::{PrimaryErrCode, SqliteError},
+    ffi,
+};
 
 use crate::sqlite::type_info::SqliteDataType;
 
@@ -52,7 +55,7 @@ impl StatementHandle {
 
     pub(crate) fn column_name(&self, index: usize) -> Result<&str, SqliteError> {
         // https://sqlite.org/c3ref/column_name.html
-        let name = ffi::column_name(self.0.as_ptr(), index as c_int);
+        let name = ffi::column_name(self.0.as_ptr(), index as i32);
         if name.is_null() {
             return Err(self.last_error());
         }
@@ -65,7 +68,7 @@ impl StatementHandle {
     }
 
     pub(crate) fn column_decltype(&self, index: usize) -> Option<SqliteDataType> {
-        let decl = ffi::column_decltype(self.0.as_ptr(), index as c_int);
+        let decl = ffi::column_decltype(self.0.as_ptr(), index as i32);
         if decl.is_null() {
             // If the Nth column of the result set is an expression or subquery,
             // then a NULL pointer is returned.
@@ -90,7 +93,7 @@ impl StatementHandle {
 
     pub(crate) fn bind_parameter_name(&self, index: usize) -> Option<&str> {
         // https://www.sqlite.org/c3ref/bind_parameter_name.html
-        let name = ffi::bind_parameter_name(self.0.as_ptr(), index as c_int);
+        let name = ffi::bind_parameter_name(self.0.as_ptr(), index as i32);
         if name.is_null() {
             return None;
         }
@@ -104,7 +107,7 @@ impl StatementHandle {
     pub(crate) fn bind_blob(&self, index: usize, v: &[u8]) -> Result<(), SqliteError> {
         ffi::bind_blob64(
             self.0.as_ptr(),
-            index as c_int,
+            index as i32,
             v.as_ptr() as *const c_void,
             v.len() as u64,
         )
@@ -113,49 +116,49 @@ impl StatementHandle {
     pub(crate) fn bind_text(&self, index: usize, v: &str) -> Result<(), SqliteError> {
         ffi::bind_text64(
             self.0.as_ptr(),
-            index as c_int,
+            index as i32,
             v.as_ptr() as *const c_char,
             v.len() as u64,
         )
     }
 
     pub(crate) fn bind_int(&self, index: usize, v: i32) -> Result<(), SqliteError> {
-        ffi::bind_int(self.0.as_ptr(), index as c_int, v as c_int)
+        ffi::bind_int(self.0.as_ptr(), index as i32, v)
     }
 
     pub(crate) fn bind_int64(&self, index: usize, v: i64) -> Result<(), SqliteError> {
-        ffi::bind_int64(self.0.as_ptr(), index as c_int, v)
+        ffi::bind_int64(self.0.as_ptr(), index as i32, v)
     }
 
     pub(crate) fn bind_double(&self, index: usize, v: f64) -> Result<(), SqliteError> {
-        ffi::bind_double(self.0.as_ptr(), index as c_int, v)
+        ffi::bind_double(self.0.as_ptr(), index as i32, v)
     }
 
     pub(crate) fn bind_null(&self, index: usize) -> Result<(), SqliteError> {
-        ffi::bind_null(self.0.as_ptr(), index as c_int)
+        ffi::bind_null(self.0.as_ptr(), index as i32)
     }
 
     // result values from the query
     // https://www.sqlite.org/c3ref/column_blob.html
 
-    pub(crate) fn column_type(&self, index: usize) -> c_int {
-        ffi::column_type(self.0.as_ptr(), index as c_int)
+    pub(crate) fn column_type(&self, index: usize) -> i32 {
+        ffi::column_type(self.0.as_ptr(), index as i32)
     }
 
     pub(crate) fn column_int64(&self, index: usize) -> i64 {
-        ffi::column_int64(self.0.as_ptr(), index as c_int)
+        ffi::column_int64(self.0.as_ptr(), index as i32)
     }
 
     pub(crate) fn column_double(&self, index: usize) -> f64 {
-        ffi::column_double(self.0.as_ptr(), index as c_int)
+        ffi::column_double(self.0.as_ptr(), index as i32)
     }
 
     pub(crate) fn column_blob(&self, index: usize) -> *const c_void {
-        ffi::column_blob(self.0.as_ptr(), index as c_int)
+        ffi::column_blob(self.0.as_ptr(), index as i32)
     }
 
     pub(crate) fn column_bytes(&self, index: usize) -> i32 {
-        ffi::column_bytes(self.0.as_ptr(), index as c_int)
+        ffi::column_bytes(self.0.as_ptr(), index as i32)
     }
 
     pub(crate) fn clear_bindings(&self) {

--- a/crates/musq/src/sqlite/statement/unlock_notify.rs
+++ b/crates/musq/src/sqlite/statement/unlock_notify.rs
@@ -1,10 +1,10 @@
 use std::ffi::c_void;
-use std::os::raw::c_int;
+
 use std::slice;
 use std::sync::{Condvar, Mutex};
 
 use crate::sqlite::ffi;
-use libsqlite3_sys::{sqlite3, sqlite3_stmt, SQLITE_LOCKED};
+use libsqlite3_sys::{SQLITE_LOCKED, sqlite3, sqlite3_stmt};
 
 use crate::{
     error::Error,
@@ -60,7 +60,7 @@ pub fn wait(conn: *mut sqlite3, stmt: Option<*mut sqlite3_stmt>) -> Result<(), E
     Ok(())
 }
 
-unsafe extern "C" fn unlock_notify_cb(ptr: *mut *mut c_void, len: c_int) {
+unsafe extern "C" fn unlock_notify_cb(ptr: *mut *mut c_void, len: i32) {
     let ptr = ptr as *mut *mut Notify;
     let slice = unsafe { slice::from_raw_parts(ptr, len as usize) };
 

--- a/crates/musq/src/sqlite/type_info.rs
+++ b/crates/musq/src/sqlite/type_info.rs
@@ -1,5 +1,4 @@
 use std::fmt::{self, Display, Formatter};
-use std::os::raw::c_int;
 use std::str::FromStr;
 
 use libsqlite3_sys::{SQLITE_BLOB, SQLITE_FLOAT, SQLITE_INTEGER, SQLITE_NULL, SQLITE_TEXT};
@@ -53,7 +52,7 @@ impl SqliteDataType {
         }
     }
 
-    pub(crate) fn from_code(code: c_int) -> Self {
+    pub(crate) fn from_code(code: i32) -> Self {
         match code {
             SQLITE_INTEGER => SqliteDataType::Int,
             SQLITE_FLOAT => SqliteDataType::Float,


### PR DESCRIPTION
## Summary
- remove use of `c_int` in sqlite FFI wrappers
- update callers to use `i32`

## Testing
- `cargo check`
- `cargo test` *(fails: concurrent_read_and_write)*

------
https://chatgpt.com/codex/tasks/task_e_687c403af9e083338dc8dced025f077b