### PR TITLE
Handle unknown SQLite type codes gracefully

### DIFF
--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -63,7 +63,7 @@ impl StatementHandle {
         Ok(unsafe { from_utf8_unchecked(CStr::from_ptr(name).to_bytes()) })
     }
 
-    pub(crate) fn column_type_info(&self, index: usize) -> SqliteDataType {
+    pub(crate) fn column_type_info(&self, index: usize) -> Option<SqliteDataType> {
         SqliteDataType::from_code(self.column_type(index))
     }
 


### PR DESCRIPTION
## Summary
- return `Option` from `SqliteDataType::from_code`
- return `Error::TypeNotFound` from `SqliteDataType::from_str`
- update `column_type_info` and usage in compound statements
- add tests for new error paths

## Testing
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c4f4262148333a650c008e7c70376