### PR TITLE
Make unlock_notify retry count configurable

### DIFF
--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -24,7 +24,6 @@ use crate::{
     Either, Error, QueryResult, Result, Row, Statement, executor::Execute, transaction::Transaction,
 };
 
-
 mod connection_like;
 
 mod connection;
@@ -32,9 +31,7 @@ mod inner;
 
 pub use self::connection::PoolConnection;
 pub use self::connection_like::ConnectionLike;
-
 #[doc(hidden)]
-
 /// An asynchronous pool of database connections.
 ///
 /// Create a pool with [Pool::connect] or [Pool::connect_with] and then call [Pool::acquire] to get a connection from

--- a/crates/musq/src/sqlite/connection/handle.rs
+++ b/crates/musq/src/sqlite/connection/handle.rs
@@ -5,8 +5,8 @@ use libsqlite3_sys::sqlite3;
 use crate::sqlite::ffi;
 
 use crate::{
-    sqlite::{statement::unlock_notify, error::ExtendedErrCode},
     Error,
+    sqlite::{error::ExtendedErrCode, statement::unlock_notify},
 };
 
 /// Managed handle to the raw SQLite3 database handle.
@@ -53,7 +53,7 @@ impl ConnectionHandle {
             match ffi::exec(self.as_ptr(), query.as_ptr()) {
                 Ok(()) => return Ok(()),
                 Err(e) if e.extended == ExtendedErrCode::LockedSharedCache => {
-                    unlock_notify::wait(self.as_ptr(), None)?;
+                    unlock_notify::wait(self.as_ptr(), None, unlock_notify::DEFAULT_MAX_RETRIES)?;
                 }
                 Err(e) => return Err(e.into()),
             }

--- a/crates/musq/src/sqlite/statement/compound.rs
+++ b/crates/musq/src/sqlite/statement/compound.rs
@@ -172,7 +172,7 @@ fn prepare_all(conn: *mut sqlite3, query: &mut Bytes) -> Result<Option<Statement
                     if e.extended == ExtendedErrCode::LockedSharedCache
                         || e.primary == PrimaryErrCode::Busy =>
                 {
-                    unlock_notify::wait(conn, None)?;
+                    unlock_notify::wait(conn, None, unlock_notify::DEFAULT_MAX_RETRIES)?;
                 }
                 Err(e) => return Err(e.into()),
             }


### PR DESCRIPTION
## Summary
- expose `DEFAULT_MAX_RETRIES` and take retry count in `unlock_notify::wait`
- use the default retry limit at all call sites
- fix a lint in `pool/mod.rs`

## Testing
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c52fcb8408333b85760120278fd26