### PR TITLE
Fix sqlite open failure cleanup

### DIFF
--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -24,7 +24,6 @@ use crate::{
     Either, Error, QueryResult, Result, Row, Statement, executor::Execute, transaction::Transaction,
 };
 
-
 mod connection_like;
 
 mod connection;
@@ -32,9 +31,7 @@ mod inner;
 
 pub use self::connection::PoolConnection;
 pub use self::connection_like::ConnectionLike;
-
 #[doc(hidden)]
-
 /// An asynchronous pool of database connections.
 ///
 /// Create a pool with [Pool::connect] or [Pool::connect_with] and then call [Pool::acquire] to get a connection from

--- a/crates/musq/src/sqlite/connection/establish.rs
+++ b/crates/musq/src/sqlite/connection/establish.rs
@@ -6,17 +6,15 @@ use std::{
     time::Duration,
 };
 
+use crate::sqlite::ffi;
 use libsqlite3_sys::{
     SQLITE_OPEN_CREATE, SQLITE_OPEN_FULLMUTEX, SQLITE_OPEN_MEMORY, SQLITE_OPEN_NOMUTEX,
     SQLITE_OPEN_PRIVATECACHE, SQLITE_OPEN_READONLY, SQLITE_OPEN_READWRITE, SQLITE_OPEN_SHAREDCACHE,
 };
-use crate::sqlite::ffi;
 
 use crate::{
     Error, Musq,
-    sqlite::{
-        connection::{ConnectionState, LogSettings, StatementCache, handle::ConnectionHandle},
-    },
+    sqlite::connection::{ConnectionState, LogSettings, StatementCache, handle::ConnectionHandle},
 };
 
 static THREAD_ID: AtomicU64 = AtomicU64::new(0);
@@ -119,11 +117,13 @@ impl EstablishParams {
             )));
         }
 
-        // SAFE: tested for NULL just above
-        // This allows any returns below to close this handle with RAII
-        let handle = unsafe { ConnectionHandle::new(handle) };
+        if let Err(e) = open_res {
+            // handle may already be closed inside `open_v2`
+            return Err(Error::Sqlite(e));
+        }
 
-        open_res.map_err(Error::Sqlite)?;
+        // SAFE: tested for NULL just above and open_v2 succeeded
+        let handle = unsafe { ConnectionHandle::new(handle) };
 
         // Enable extended result codes
         // https://www.sqlite.org/c3ref/extended_result_codes.html

--- a/crates/musq/src/sqlite/ffi.rs
+++ b/crates/musq/src/sqlite/ffi.rs
@@ -37,6 +37,11 @@ pub(crate) fn open_v2(
                 message: "sqlite3_open_v2 failed".into(),
             })
         } else {
+            // SAFETY: db is valid when rc != SQLITE_OK and not null
+            unsafe {
+                ffi_sys::sqlite3_close(db);
+            }
+
             Err(SqliteError::new(db))
         }
     }

--- a/crates/musq/tests/error.rs
+++ b/crates/musq/tests/error.rs
@@ -73,3 +73,20 @@ async fn it_fails_with_check_violation() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn it_fails_to_open() -> anyhow::Result<()> {
+    use musq::{Connection, Musq};
+    use tempdir::TempDir;
+
+    let dir = TempDir::new("musq-open-fail")?;
+    let path = dir.path().join("nonexistent.db");
+
+    let options = Musq::new().filename(&path);
+    let res = Connection::connect_with(&options).await;
+
+    let err = res.unwrap_err();
+    assert!(err.into_sqlite_error().is_some());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- close sqlite handle before constructing error
- handle closed sqlite handles in connection establishment
- add regression test for failed open

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c53ffd5248333b0c1424374239837