### PR TITLE
Return Result from numeric Value getters

### DIFF
--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -24,7 +24,6 @@ use crate::{
     Either, Error, QueryResult, Result, Row, Statement, executor::Execute, transaction::Transaction,
 };
 
-
 mod connection_like;
 
 mod connection;
@@ -32,9 +31,7 @@ mod inner;
 
 pub use self::connection::PoolConnection;
 pub use self::connection_like::ConnectionLike;
-
 #[doc(hidden)]
-
 /// An asynchronous pool of database connections.
 ///
 /// Create a pool with [Pool::connect] or [Pool::connect_with] and then call [Pool::acquire] to get a connection from

--- a/crates/musq/src/sqlite/value.rs
+++ b/crates/musq/src/sqlite/value.rs
@@ -19,21 +19,21 @@ pub(crate) enum ValueData {
 
 impl Value {
     pub fn int(&self) -> Result<i32, DecodeError> {
-        Ok(i32::try_from(self.int64())?)
+        Ok(i32::try_from(self.int64()?)?)
     }
 
-    pub fn int64(&self) -> i64 {
+    pub fn int64(&self) -> Result<i64, DecodeError> {
         match self.data {
-            ValueData::Integer(v) => v,
-            _ => 0,
+            ValueData::Integer(v) => Ok(v),
+            _ => Err(DecodeError::Conversion("not an integer".into())),
         }
     }
 
-    pub fn double(&self) -> f64 {
+    pub fn double(&self) -> Result<f64, DecodeError> {
         match self.data {
-            ValueData::Double(v) => v,
-            ValueData::Integer(v) => v as f64,
-            _ => 0.0,
+            ValueData::Double(v) => Ok(v),
+            ValueData::Integer(v) => Ok(v as f64),
+            _ => Err(DecodeError::Conversion("not a float".into())),
         }
     }
 

--- a/crates/musq/src/types/float.rs
+++ b/crates/musq/src/types/float.rs
@@ -15,7 +15,7 @@ impl Encode for f32 {
 impl<'r> Decode<'r> for f32 {
     fn decode(value: &'r Value) -> Result<f32, DecodeError> {
         compatible!(value, SqliteDataType::Float);
-        Ok(value.double() as f32)
+        Ok(value.double()? as f32)
     }
 }
 
@@ -28,6 +28,6 @@ impl Encode for f64 {
 impl<'r> Decode<'r> for f64 {
     fn decode(value: &'r Value) -> Result<f64, DecodeError> {
         compatible!(value, SqliteDataType::Float);
-        Ok(value.double())
+        value.double()
     }
 }

--- a/crates/musq/src/types/int.rs
+++ b/crates/musq/src/types/int.rs
@@ -56,6 +56,6 @@ impl Encode for i64 {
 impl<'r> Decode<'r> for i64 {
     fn decode(value: &'r Value) -> Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
-        Ok(value.int64())
+        value.int64()
     }
 }

--- a/crates/musq/src/types/time.rs
+++ b/crates/musq/src/types/time.rs
@@ -83,7 +83,7 @@ fn decode_offset_datetime(value: &Value) -> Result<OffsetDateTime, DecodeError> 
     let dt = match value.type_info() {
         SqliteDataType::Text => decode_offset_datetime_from_text(value.text()?),
         SqliteDataType::Int | SqliteDataType::Int64 => Some(
-            OffsetDateTime::from_unix_timestamp(value.int64())
+            OffsetDateTime::from_unix_timestamp(value.int64()?)
                 .map_err(|e| DecodeError::Conversion(e.to_string()))?,
         ),
 
@@ -121,7 +121,7 @@ fn decode_datetime(value: &Value) -> Result<PrimitiveDateTime, DecodeError> {
     let dt = match value.type_info() {
         SqliteDataType::Text => decode_datetime_from_text(value.text()?),
         SqliteDataType::Int | SqliteDataType::Int64 => {
-            let parsed = OffsetDateTime::from_unix_timestamp(value.int64()).unwrap();
+            let parsed = OffsetDateTime::from_unix_timestamp(value.int64()?).unwrap();
             Some(PrimitiveDateTime::new(parsed.date(), parsed.time()))
         }
         _ => None,

--- a/crates/musq/src/types/uint.rs
+++ b/crates/musq/src/types/uint.rs
@@ -43,6 +43,6 @@ impl Encode for u32 {
 impl<'r> Decode<'r> for u32 {
     fn decode(value: &'r Value) -> Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
-        Ok(value.int64().try_into()?)
+        Ok(value.int64()?.try_into()?)
     }
 }

--- a/crates/musq/tests/sqlite.rs
+++ b/crates/musq/tests/sqlite.rs
@@ -443,10 +443,10 @@ SELECT id, text FROM _musq_test;
 
     let row = cursor.try_next().await?.unwrap();
 
-    let id: i64 = row.get_value("id")?;
+    let id: Option<i64> = row.get_value("id")?;
     let text: &str = row.get_value("text")?;
 
-    assert_eq!(0, id);
+    assert_eq!(None, id);
     assert_eq!("this is a test", text);
 
     Ok(())
@@ -587,8 +587,7 @@ async fn it_resets_prepared_statement_after_fetch_many() -> anyhow::Result<()> {
 #[tokio::test]
 async fn it_can_transact() {
     let pool = Musq::new().open_in_memory().await.unwrap();
-    pool
-        .execute(query("CREATE TABLE foo (value INTEGER)"))
+    pool.execute(query("CREATE TABLE foo (value INTEGER)"))
         .await
         .unwrap();
 
@@ -786,14 +785,13 @@ async fn concurrent_read_and_write() {
         let pool = pool.clone();
         async move {
             for i in 0u32..n {
-                pool
-                    .execute(
-                        query("INSERT INTO kv (k, v) VALUES (?, ?)")
-                            .bind(i)
-                            .bind(i * i),
-                    )
-                    .await
-                    .unwrap();
+                pool.execute(
+                    query("INSERT INTO kv (k, v) VALUES (?, ?)")
+                        .bind(i)
+                        .bind(i * i),
+                )
+                .await
+                .unwrap();
             }
         }
     });


### PR DESCRIPTION
## Summary
- prevent silent data conversion by returning `Result` from `Value` numeric accessors
- adjust decoders to propagate the new errors
- update tests for new behavior
- satisfy clippy by removing stray newline

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c542c4c9883338dd050e920fe5765