### PR TITLE
Fix progress handler drop

### DIFF
--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -24,7 +24,6 @@ use crate::{
     Either, Error, QueryResult, Result, Row, Statement, executor::Execute, transaction::Transaction,
 };
 
-
 mod connection_like;
 
 mod connection;
@@ -34,7 +33,6 @@ pub use self::connection::PoolConnection;
 pub use self::connection_like::ConnectionLike;
 
 #[doc(hidden)]
-
 /// An asynchronous pool of database connections.
 ///
 /// Create a pool with [Pool::connect] or [Pool::connect_with] and then call [Pool::acquire] to get a connection from

--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -72,10 +72,10 @@ pub(crate) struct ConnectionState {
 impl ConnectionState {
     /// Drops the `progress_handler_callback` if it exists.
     pub(crate) fn remove_progress_handler(&mut self) {
-        if let Some(mut handler) = self.progress_handler_callback.take() {
+        if let Some(handler) = self.progress_handler_callback.take() {
             unsafe {
                 ffi::progress_handler(self.handle.as_ptr(), 0, None, std::ptr::null_mut());
-                let _ = { Box::from_raw(handler.0.as_mut()) };
+                let _ = { Box::from_raw(handler.0.as_ptr()) };
             }
         }
     }


### PR DESCRIPTION
## Summary
- free SQLite progress handler without mut reference
- remove stray newline in pool module

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c543f171c8333b62dc6e78dbe2cc6