### PR TITLE
Use owned Strings for statement metadata names

### DIFF
--- a/crates/musq/src/sqlite/arguments.rs
+++ b/crates/musq/src/sqlite/arguments.rs
@@ -69,7 +69,7 @@ impl Arguments {
             // Figure out the index of this bind parameter into our argument tuple.
             let n: usize = if let Some(name) = handle.bind_parameter_name(param_i) {
                 if name.starts_with('?') {
-                    parse_question_param(name)?
+                    parse_question_param(&name)?
                 } else if let Some(rest) = name.strip_prefix('$') {
                     // parameters of the form $NNN are positional, otherwise they are named
                     if let Some(n) = atoi(rest.as_bytes()) {

--- a/crates/musq/src/sqlite/statement/compound.rs
+++ b/crates/musq/src/sqlite/statement/compound.rs
@@ -95,7 +95,7 @@ impl CompoundStatement {
                     let mut column_names = HashMap::with_capacity(num);
 
                     for i in 0..num {
-                        let name: UStr = statement.column_name(i)?.to_owned().into();
+                        let name: UStr = statement.column_name(i)?.into();
                         let type_info = statement
                             .column_decltype(i)
                             .or_else(|| statement.column_type_info(i))

--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -53,14 +53,15 @@ impl StatementHandle {
         unsafe { ffi::changes(self.db_handle()) as u64 }
     }
 
-    pub(crate) fn column_name(&self, index: usize) -> Result<&str, SqliteError> {
+    pub(crate) fn column_name(&self, index: usize) -> Result<String, SqliteError> {
         // https://sqlite.org/c3ref/column_name.html
         let name = ffi::column_name(self.0.as_ptr(), index as i32);
         if name.is_null() {
             return Err(self.last_error());
         }
 
-        Ok(unsafe { from_utf8_unchecked(CStr::from_ptr(name).to_bytes()) })
+        let s = unsafe { CStr::from_ptr(name) };
+        Ok(s.to_string_lossy().into_owned())
     }
 
     pub(crate) fn column_type_info(&self, index: usize) -> Option<SqliteDataType> {
@@ -91,14 +92,15 @@ impl StatementHandle {
     // Name Of A Host Parameter
     // NOTE: The first host parameter has an index of 1, not 0.
 
-    pub(crate) fn bind_parameter_name(&self, index: usize) -> Option<&str> {
+    pub(crate) fn bind_parameter_name(&self, index: usize) -> Option<String> {
         // https://www.sqlite.org/c3ref/bind_parameter_name.html
         let name = ffi::bind_parameter_name(self.0.as_ptr(), index as i32);
         if name.is_null() {
             return None;
         }
 
-        Some(unsafe { from_utf8_unchecked(CStr::from_ptr(name).to_bytes()) })
+        let s = unsafe { CStr::from_ptr(name) };
+        Some(s.to_string_lossy().into_owned())
     }
 
     // Binding Values To Prepared Statements


### PR DESCRIPTION
## Summary
- return `String` from `StatementHandle::column_name`
- return `String` from `StatementHandle::bind_parameter_name`
- update callers to handle owned names

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687c58ea1b148333a6e5b812c7ff7858