### PR TITLE
Remove IndexMap re-export

### DIFF
--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -21,7 +21,6 @@ mod transaction;
 pub mod types;
 
 pub use either::Either;
-pub use indexmap::IndexMap;
 
 pub use crate::{
     column::Column,


### PR DESCRIPTION
## Summary
- clean up the musq public API by removing the `IndexMap` re-export

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c5d104e4c8333a13518727bc5acd2