### PR TITLE
Change transaction helper visibility

### DIFF
--- a/crates/musq/src/transaction.rs
+++ b/crates/musq/src/transaction.rs
@@ -132,16 +132,16 @@ where
     }
 }
 
-pub fn begin_ansi_transaction_sql(depth: usize) -> String {
+pub(crate) fn begin_ansi_transaction_sql(depth: usize) -> String {
     // The first savepoint is equivalent to a BEGIN
     format!("SAVEPOINT _musq_savepoint_{depth}")
 }
 
-pub fn commit_ansi_transaction_sql(depth: usize) -> String {
+pub(crate) fn commit_ansi_transaction_sql(depth: usize) -> String {
     format!("RELEASE SAVEPOINT _musq_savepoint_{}", depth - 1)
 }
 
-pub fn rollback_ansi_transaction_sql(depth: usize) -> String {
+pub(crate) fn rollback_ansi_transaction_sql(depth: usize) -> String {
     if depth == 1 {
         "ROLLBACK".into()
     } else {


### PR DESCRIPTION
## Summary
- restrict `begin_ansi_transaction_sql`, `commit_ansi_transaction_sql`, and `rollback_ansi_transaction_sql` to crate scope
- keep worker imports referencing these crate-visible helpers

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`

------
https://chatgpt.com/codex/tasks/task_e_687c5d33707c8333b39b214e8bd1f549