### PR TITLE
Remove either::Either re-export

### DIFF
--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -20,7 +20,6 @@ mod statement_cache;
 mod transaction;
 pub mod types;
 
-pub use either::Either;
 pub use indexmap::IndexMap;
 
 pub use crate::{

--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -21,8 +21,9 @@ use futures_util::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, future};
 
 use self::inner::PoolInner;
 use crate::{
-    Either, Error, QueryResult, Result, Row, Statement, executor::Execute, transaction::Transaction,
+    Error, QueryResult, Result, Row, Statement, executor::Execute, transaction::Transaction,
 };
+use either::Either;
 
 mod connection_like;
 

--- a/crates/musq/src/sqlite/connection/execute.rs
+++ b/crates/musq/src/sqlite/connection/execute.rs
@@ -1,5 +1,7 @@
+use either::Either;
+
 use crate::{
-    Either, Error, QueryResult, Row,
+    Error, QueryResult, Row,
     logger::{NopQueryLogger, QueryLog, QueryLogger},
     sqlite::{
         Arguments,

--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -11,8 +11,10 @@ use futures_util::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, future};
 use libsqlite3_sys::sqlite3;
 use tokio::sync::MutexGuard;
 
+use either::Either;
+
 use crate::{
-    Either, QueryResult, Result, Row, Statement,
+    QueryResult, Result, Row, Statement,
     error::Error,
     executor::Execute,
     logger::LogSettings,

--- a/crates/musq/src/sqlite/connection/worker.rs
+++ b/crates/musq/src/sqlite/connection/worker.rs
@@ -6,8 +6,10 @@ use std::thread;
 use tokio::sync::oneshot;
 use tokio::sync::{Mutex, MutexGuard};
 
+use either::Either;
+
 use crate::{
-    Either, QueryResult, Row,
+    QueryResult, Row,
     error::Error,
     sqlite::{
         Arguments, Statement,


### PR DESCRIPTION
## Summary
- remove public re-export of `Either`
- qualify uses of `Either` inside the library

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687c5d44f03c833384869b56cbb3d40a