### PR TITLE
Update pool docs

### DIFF
--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -34,8 +34,8 @@ pub use self::connection_like::ConnectionLike;
 #[doc(hidden)]
 /// An asynchronous pool of database connections.
 ///
-/// Create a pool with [Pool::connect] or [Pool::connect_with] and then call [Pool::acquire] to get a connection from
-/// the pool; when the connection is dropped it will return to the pool so it can be reused.
+/// Create a pool with [`Musq::open`] or [`Musq::open_in_memory`] and then call [`Pool::acquire`] to get a connection
+/// from the pool; when the connection is dropped it will return to the pool so it can be reused.
 ///
 /// You can also execute queries directly on `&Pool`; this will automatically checkout a connection
 /// for you.


### PR DESCRIPTION
## Summary
- fix the docs for creating a pool by referencing `Musq::open` and `Musq::open_in_memory`

## Testing
- `cargo clippy --workspace --all-targets --all-features -q`
- `cargo test --workspace --all-targets --all-features -q`

------
https://chatgpt.com/codex/tasks/task_e_687c5d7ae4d48333a05441ce4ef676e4