### PR TITLE
Encapsulate row internals

### DIFF
--- a/crates/musq/src/row.rs
+++ b/crates/musq/src/row.rs
@@ -11,8 +11,8 @@ use crate::{
 /// Implementation of [`Row`] for SQLite.
 #[derive(Clone)]
 pub struct Row {
-    pub values: Box<[Value]>,
-    pub columns: Arc<Vec<Column>>,
+    values: Box<[Value]>,
+    columns: Arc<Vec<Column>>,
     pub(crate) column_names: Arc<HashMap<UStr, usize>>,
 }
 
@@ -77,6 +77,16 @@ impl Row {
             columns: Arc::clone(columns),
             column_names: Arc::clone(column_names),
         }
+    }
+
+    /// Returns the values for this row.
+    pub fn values(&self) -> &[Value] {
+        self.values.as_ref()
+    }
+
+    /// Returns the column definitions for this row.
+    pub fn columns(&self) -> &[Column] {
+        self.columns.as_ref()
     }
 
     /// Returns `true` if this row has no columns.


### PR DESCRIPTION
## Summary
- hide `Row`'s `values` and `columns` fields
- expose `values()` and `columns()` accessors

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c5d3d79f48333bafdeaeb73eddd10