### PR TITLE
Simplify Result alias

### DIFF
--- a/crates/musq-macros/src/json.rs
+++ b/crates/musq-macros/src/json.rs
@@ -31,7 +31,7 @@ pub fn expand_json(input: &DeriveInput) -> syn::Result<TokenStream> {
         }
 
         impl #decode_impl_generics musq::decode::Decode<'r> for #ident #ty_generics #where_clause {
-            fn decode(value: &'r musq::Value) -> Result<Self, musq::DecodeError> {
+            fn decode(value: &'r musq::Value) -> std::result::Result<Self, musq::DecodeError> {
                 serde_json::from_str(value.text()?).map_err(|x| musq::DecodeError::Conversion(x.to_string().into()))
             }
         }

--- a/crates/musq/src/decode.rs
+++ b/crates/musq/src/decode.rs
@@ -1,10 +1,10 @@
 //! Provides [`Decode`] for decoding values from the database.
-use crate::{Result, Value, error::DecodeError};
+use crate::{Value, error::DecodeError};
 
 /// A type that can be decoded from the database.
 pub trait Decode<'r>: Sized {
     /// Decode a new value of this type using a raw value from the database.
-    fn decode(value: &'r Value) -> Result<Self, DecodeError>;
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError>;
 }
 
 // implement `Decode` for Option<T> for all SQL types
@@ -12,7 +12,7 @@ impl<'r, T> Decode<'r> for Option<T>
 where
     T: Decode<'r>,
 {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         if value.is_null() {
             Ok(None)
         } else {

--- a/crates/musq/src/error.rs
+++ b/crates/musq/src/error.rs
@@ -6,7 +6,7 @@ use std::num::TryFromIntError;
 use crate::{SqliteDataType, sqlite, sqlite::error::SqliteError};
 
 /// A specialized `Result` type for Musq.
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum DecodeError {

--- a/crates/musq/src/from_row.rs
+++ b/crates/musq/src/from_row.rs
@@ -1,5 +1,5 @@
 use crate::Row;
-use crate::error::Error;
+use crate::error::Result;
 
 /// A record that can be built from a row returned by the database.
 ///
@@ -192,7 +192,7 @@ use crate::error::Error;
 /// }
 /// ```
 pub trait FromRow<'r>: Sized {
-    fn from_row(prefix: &str, row: &'r Row) -> Result<Self, Error>;
+    fn from_row(prefix: &str, row: &'r Row) -> Result<Self>;
 }
 
 // implement FromRow for tuples of types that implement Decode
@@ -205,7 +205,7 @@ macro_rules! impl_from_row_for_tuple {
             $($T: crate::decode::Decode<'r>,)+
         {
 
-            fn from_row(_prefix: &str, row: &'r Row) -> Result<Self, Error> {
+            fn from_row(_prefix: &str, row: &'r Row) -> Result<Self> {
                 Ok(($(row.get_value_idx($idx as usize)?,)+))
             }
         }

--- a/crates/musq/src/pool/connection.rs
+++ b/crates/musq/src/pool/connection.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-use crate::{Connection, error::Error};
+use crate::{Connection, Result};
 
 use super::inner::{DecrementSizeGuard, PoolInner};
 use std::future::Future;
@@ -72,7 +72,7 @@ impl PoolConnection {
     ///
     /// [`.detach()`]: PoolConnection::detach
     /// [`.close()`]: Connection::close
-    pub async fn close(mut self) -> Result<(), Error> {
+    pub async fn close(mut self) -> Result<()> {
         let floating = self.take_live().float(self.pool.clone());
         floating.inner.raw.close().await
     }

--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -320,7 +320,7 @@ impl CloseEvent {
             // Can't really factor out mapping to `Err(Error::PoolClosed)` though it seems like
             // we should because that results in a different `Ok` type each time.
             //
-            // Ideally we'd map to something like `Result<!, Error>` but using `!` as a type
+            // Ideally we'd map to something like `Result<!>` but using `!` as a type
             // is not allowed on stable Rust yet.
             self.poll_unpin(cx).map(|_| Err(Error::PoolClosed))
         })

--- a/crates/musq/src/row.rs
+++ b/crates/musq/src/row.rs
@@ -119,7 +119,7 @@ impl Row {
 }
 
 impl<'r> crate::from_row::FromRow<'r> for Row {
-    fn from_row(_prefix: &str, row: &'r Row) -> Result<Self, Error> {
+    fn from_row(_prefix: &str, row: &'r Row) -> Result<Self> {
         Ok(row.clone())
     }
 }

--- a/crates/musq/src/sqlite/arguments.rs
+++ b/crates/musq/src/sqlite/arguments.rs
@@ -1,9 +1,9 @@
-use crate::{Error, encode::Encode, sqlite::statement::StatementHandle};
+use crate::{Error, Result, encode::Encode, sqlite::statement::StatementHandle};
 use std::collections::HashMap;
 
 use atoi::atoi;
 
-pub(crate) fn parse_question_param(name: &str) -> Result<usize, Error> {
+pub(crate) fn parse_question_param(name: &str) -> Result<usize> {
     let rest = name.trim_start_matches('?');
     atoi::<usize>(rest.as_bytes())
         .ok_or_else(|| Error::Protocol(format!("invalid numeric SQL parameter: {name}")))
@@ -50,7 +50,7 @@ impl Arguments {
         }
     }
 
-    pub(super) fn bind(&self, handle: &mut StatementHandle, offset: usize) -> Result<usize, Error> {
+    pub(super) fn bind(&self, handle: &mut StatementHandle, offset: usize) -> Result<usize> {
         let mut next_pos = offset;
         if let Some(max) = self.named.values().max().cloned() {
             if max > next_pos {
@@ -126,7 +126,7 @@ impl Arguments {
 }
 
 impl ArgumentValue {
-    fn bind(&self, handle: &mut StatementHandle, i: usize) -> Result<(), Error> {
+    fn bind(&self, handle: &mut StatementHandle, i: usize) -> Result<()> {
         use ArgumentValue::*;
 
         match self {

--- a/crates/musq/src/sqlite/connection/establish.rs
+++ b/crates/musq/src/sqlite/connection/establish.rs
@@ -13,7 +13,7 @@ use libsqlite3_sys::{
 };
 
 use crate::{
-    Error, Musq,
+    Error, Musq, Result,
     sqlite::connection::{ConnectionState, LogSettings, StatementCache, handle::ConnectionHandle},
 };
 
@@ -30,7 +30,7 @@ pub struct EstablishParams {
 }
 
 impl EstablishParams {
-    pub fn from_options(options: &Musq) -> Result<Self, Error> {
+    pub fn from_options(options: &Musq) -> Result<Self> {
         let mut filename = options
             .filename
             .to_str()
@@ -108,7 +108,7 @@ impl EstablishParams {
     /// The configured busy timeout is converted to milliseconds for
     /// [`sqlite3_busy_timeout`]. If the duration exceeds `i32::MAX`
     /// milliseconds, it is clamped to `i32::MAX`.
-    pub(crate) fn establish(&self) -> Result<ConnectionState, Error> {
+    pub(crate) fn establish(&self) -> Result<ConnectionState> {
         let mut handle = null_mut();
 
         // <https://www.sqlite.org/c3ref/open.html>

--- a/crates/musq/src/sqlite/connection/execute.rs
+++ b/crates/musq/src/sqlite/connection/execute.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Either, Error, QueryResult, Row,
+    Either, QueryResult, Result, Row,
     logger::{NopQueryLogger, QueryLog, QueryLogger},
     sqlite::{
         Arguments,
@@ -25,7 +25,7 @@ pub(crate) fn iter<'a>(
     conn: &'a mut ConnectionState,
     query: &'a str,
     args: Option<Arguments>,
-) -> Result<ExecuteIter<'a>, Error> {
+) -> Result<ExecuteIter<'a>> {
     // fetch the cached statement or allocate a new one
     let statement = conn.statements.get(query)?;
 
@@ -49,7 +49,7 @@ fn bind(
     statement: &mut StatementHandle,
     arguments: &Option<Arguments>,
     offset: usize,
-) -> Result<usize, Error> {
+) -> Result<usize> {
     let mut n = 0;
 
     if let Some(arguments) = arguments {
@@ -60,7 +60,7 @@ fn bind(
 }
 
 impl Iterator for ExecuteIter<'_> {
-    type Item = Result<Either<QueryResult, Row>, Error>;
+    type Item = Result<Either<QueryResult, Row>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let statement = if self.goto_next {

--- a/crates/musq/src/sqlite/connection/handle.rs
+++ b/crates/musq/src/sqlite/connection/handle.rs
@@ -5,7 +5,7 @@ use libsqlite3_sys::sqlite3;
 use crate::sqlite::ffi;
 
 use crate::{
-    Error,
+    Error, Result,
     sqlite::{error::ExtendedErrCode, statement::unlock_notify},
 };
 
@@ -43,7 +43,7 @@ impl ConnectionHandle {
         ffi::last_insert_rowid(self.as_ptr())
     }
 
-    pub(crate) fn exec(&self, query: impl Into<String>) -> Result<(), Error> {
+    pub(crate) fn exec(&self, query: impl Into<String>) -> Result<()> {
         let query = query.into();
         let query =
             CString::new(query).map_err(|_| Error::Protocol("query contains nul bytes".into()))?;

--- a/crates/musq/src/sqlite/connection/worker.rs
+++ b/crates/musq/src/sqlite/connection/worker.rs
@@ -8,7 +8,7 @@ use tokio::sync::{Mutex, MutexGuard};
 
 use crate::{
     Either, QueryResult, Row,
-    error::Error,
+    error::{Error, Result},
     sqlite::{
         Arguments, Statement,
         connection::{ConnectionState, establish::EstablishParams, execute},
@@ -37,21 +37,21 @@ pub(crate) struct WorkerSharedState {
 enum Command {
     Prepare {
         query: Box<str>,
-        tx: oneshot::Sender<Result<Statement, Error>>,
+        tx: oneshot::Sender<Result<Statement>>,
     },
     Execute {
         query: Box<str>,
         arguments: Option<Arguments>,
-        tx: flume::Sender<Result<Either<QueryResult, Row>, Error>>,
+        tx: flume::Sender<Result<Either<QueryResult, Row>>>,
     },
     Begin {
-        tx: rendezvous_oneshot::Sender<Result<(), Error>>,
+        tx: rendezvous_oneshot::Sender<Result<()>>,
     },
     Commit {
-        tx: rendezvous_oneshot::Sender<Result<(), Error>>,
+        tx: rendezvous_oneshot::Sender<Result<()>>,
     },
     Rollback {
-        tx: Option<rendezvous_oneshot::Sender<Result<(), Error>>>,
+        tx: Option<rendezvous_oneshot::Sender<Result<()>>>,
     },
     UnlockDb,
     ClearCache {
@@ -63,7 +63,7 @@ enum Command {
 }
 
 impl ConnectionWorker {
-    pub(crate) async fn establish(params: EstablishParams) -> Result<Self, Error> {
+    pub(crate) async fn establish(params: EstablishParams) -> Result<Self> {
         let (establish_tx, establish_rx) = oneshot::channel();
 
         let join_handle = thread::Builder::new()
@@ -245,7 +245,7 @@ impl ConnectionWorker {
         })
     }
 
-    pub(crate) async fn prepare(&mut self, query: &str) -> Result<Statement, Error> {
+    pub(crate) async fn prepare(&mut self, query: &str) -> Result<Statement> {
         self.oneshot_cmd(|tx| Command::Prepare {
             query: query.into(),
             tx,
@@ -259,7 +259,7 @@ impl ConnectionWorker {
         query: String,
         args: Option<Arguments>,
         chan_size: usize,
-    ) -> Result<flume::Receiver<Result<Either<QueryResult, Row>, Error>>, Error> {
+    ) -> Result<flume::Receiver<Result<Either<QueryResult, Row>>>> {
         let (tx, rx) = flume::bounded(chan_size);
 
         self.command_tx
@@ -274,28 +274,28 @@ impl ConnectionWorker {
         Ok(rx)
     }
 
-    pub(crate) async fn begin(&mut self) -> Result<(), Error> {
+    pub(crate) async fn begin(&mut self) -> Result<()> {
         self.oneshot_cmd_with_ack(|tx| Command::Begin { tx })
             .await?
     }
 
-    pub(crate) async fn commit(&mut self) -> Result<(), Error> {
+    pub(crate) async fn commit(&mut self) -> Result<()> {
         self.oneshot_cmd_with_ack(|tx| Command::Commit { tx })
             .await?
     }
 
-    pub(crate) async fn rollback(&mut self) -> Result<(), Error> {
+    pub(crate) async fn rollback(&mut self) -> Result<()> {
         self.oneshot_cmd_with_ack(|tx| Command::Rollback { tx: Some(tx) })
             .await?
     }
 
-    pub(crate) fn start_rollback(&mut self) -> Result<(), Error> {
+    pub(crate) fn start_rollback(&mut self) -> Result<()> {
         self.command_tx
             .send(Command::Rollback { tx: None })
             .map_err(|_| Error::WorkerCrashed)
     }
 
-    async fn oneshot_cmd<F, T>(&mut self, command: F) -> Result<T, Error>
+    async fn oneshot_cmd<F, T>(&mut self, command: F) -> Result<T>
     where
         F: FnOnce(oneshot::Sender<T>) -> Command,
     {
@@ -309,7 +309,7 @@ impl ConnectionWorker {
         rx.await.map_err(|_| Error::WorkerCrashed)
     }
 
-    async fn oneshot_cmd_with_ack<F, T>(&mut self, command: F) -> Result<T, Error>
+    async fn oneshot_cmd_with_ack<F, T>(&mut self, command: F) -> Result<T>
     where
         F: FnOnce(rendezvous_oneshot::Sender<T>) -> Command,
     {
@@ -323,11 +323,11 @@ impl ConnectionWorker {
         rx.recv().await.map_err(|_| Error::WorkerCrashed)
     }
 
-    pub(crate) async fn clear_cache(&mut self) -> Result<(), Error> {
+    pub(crate) async fn clear_cache(&mut self) -> Result<()> {
         self.oneshot_cmd(|tx| Command::ClearCache { tx }).await
     }
 
-    pub(crate) async fn unlock_db(&mut self) -> Result<MutexGuard<'_, ConnectionState>, Error> {
+    pub(crate) async fn unlock_db(&mut self) -> Result<MutexGuard<'_, ConnectionState>> {
         let (guard, res) = futures_util::future::join(
             // we need to join the wait queue for the lock before we send the message
             self.shared.conn.lock(),
@@ -343,7 +343,7 @@ impl ConnectionWorker {
     /// Send a command to the worker to shut down the processing thread.
     ///
     /// A `WorkerCrashed` error may be returned if the thread has already stopped.
-    pub(crate) fn shutdown(&mut self) -> impl Future<Output = Result<(), Error>> {
+    pub(crate) fn shutdown(&mut self) -> impl Future<Output = Result<()>> {
         let join_handle = self.join_handle.take();
         let (tx, rx) = oneshot::channel();
 
@@ -372,7 +372,7 @@ impl ConnectionWorker {
     }
 }
 
-fn prepare(conn: &mut ConnectionState, query: &str) -> Result<Statement, Error> {
+fn prepare(conn: &mut ConnectionState, query: &str) -> Result<Statement> {
     // prepare statement object (or checkout from cache)
     let statement = conn.statements.get(query)?;
 
@@ -412,14 +412,14 @@ mod rendezvous_oneshot {
     }
 
     impl<T> Sender<T> {
-        pub async fn send(self, value: T) -> Result<(), Canceled> {
+        pub async fn send(self, value: T) -> std::result::Result<(), Canceled> {
             let (ack_tx, ack_rx) = oneshot::channel();
             self.inner.send((value, ack_tx)).map_err(|_| Canceled)?;
             ack_rx.await.map_err(|_| Canceled)?;
             Ok(())
         }
 
-        pub fn blocking_send(self, value: T) -> Result<(), Canceled> {
+        pub fn blocking_send(self, value: T) -> std::result::Result<(), Canceled> {
             futures_executor::block_on(self.send(value))
         }
     }
@@ -429,7 +429,7 @@ mod rendezvous_oneshot {
     }
 
     impl<T> Receiver<T> {
-        pub async fn recv(self) -> Result<T, Canceled> {
+        pub async fn recv(self) -> std::result::Result<T, Canceled> {
             let (value, ack_tx) = self.inner.await.map_err(|_| Canceled)?;
             ack_tx.send(()).map_err(|_| Canceled)?;
             Ok(value)

--- a/crates/musq/src/sqlite/ffi.rs
+++ b/crates/musq/src/sqlite/ffi.rs
@@ -23,7 +23,7 @@ pub(crate) fn open_v2(
     handle: *mut *mut sqlite3,
     flags: i32,
     vfs: *const c_char,
-) -> Result<(), SqliteError> {
+) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_open_v2(filename, handle, flags as c_int, vfs) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -48,7 +48,10 @@ pub(crate) fn open_v2(
 }
 
 /// Wrapper around [`sqlite3_extended_result_codes`].
-pub(crate) fn extended_result_codes(db: *mut sqlite3, onoff: i32) -> Result<(), SqliteError> {
+pub(crate) fn extended_result_codes(
+    db: *mut sqlite3,
+    onoff: i32,
+) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_extended_result_codes(db, onoff as c_int) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -58,7 +61,7 @@ pub(crate) fn extended_result_codes(db: *mut sqlite3, onoff: i32) -> Result<(), 
 }
 
 /// Wrapper around [`sqlite3_busy_timeout`].
-pub(crate) fn busy_timeout(db: *mut sqlite3, ms: i32) -> Result<(), SqliteError> {
+pub(crate) fn busy_timeout(db: *mut sqlite3, ms: i32) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_busy_timeout(db, ms as c_int) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -75,7 +78,7 @@ pub(crate) fn prepare_v3(
     flags: u32,
     stmt: *mut *mut sqlite3_stmt,
     tail: *mut *const c_char,
-) -> Result<(), SqliteError> {
+) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_prepare_v3(db, sql, n_byte as c_int, flags, stmt, tail) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -101,7 +104,7 @@ pub(crate) fn unlock_notify(
     db: *mut sqlite3,
     callback: Option<unsafe extern "C" fn(*mut *mut c_void, c_int)>,
     arg: *mut c_void,
-) -> Result<(), SqliteError> {
+) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_unlock_notify(db, callback, arg) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -121,7 +124,7 @@ pub(crate) fn errmsg(db: *mut sqlite3) -> *const c_char {
 }
 
 /// Wrapper around [`sqlite3_close`].
-pub(crate) fn close(db: *mut sqlite3) -> Result<(), SqliteError> {
+pub(crate) fn close(db: *mut sqlite3) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_close(db) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -131,7 +134,7 @@ pub(crate) fn close(db: *mut sqlite3) -> Result<(), SqliteError> {
 }
 
 /// Wrapper around [`sqlite3_exec`] with no callback.
-pub(crate) fn exec(db: *mut sqlite3, sql: *const c_char) -> Result<(), SqliteError> {
+pub(crate) fn exec(db: *mut sqlite3, sql: *const c_char) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_exec(db, sql, None, ptr::null_mut(), ptr::null_mut()) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -186,7 +189,7 @@ pub(crate) fn bind_blob64(
     index: i32,
     data: *const c_void,
     len: u64,
-) -> Result<(), SqliteError> {
+) -> std::result::Result<(), SqliteError> {
     let rc = unsafe {
         ffi_sys::sqlite3_bind_blob64(stmt, index, data, len, ffi_sys::SQLITE_TRANSIENT())
     };
@@ -204,7 +207,7 @@ pub(crate) fn bind_text64(
     index: i32,
     data: *const c_char,
     len: u64,
-) -> Result<(), SqliteError> {
+) -> std::result::Result<(), SqliteError> {
     unsafe {
         let rc = ffi_sys::sqlite3_bind_text64(
             stmt,
@@ -224,7 +227,11 @@ pub(crate) fn bind_text64(
 }
 
 /// Wrapper around [`sqlite3_bind_int`].
-pub(crate) fn bind_int(stmt: *mut sqlite3_stmt, index: i32, value: i32) -> Result<(), SqliteError> {
+pub(crate) fn bind_int(
+    stmt: *mut sqlite3_stmt,
+    index: i32,
+    value: i32,
+) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_bind_int(stmt, index as c_int, value as c_int) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -239,7 +246,7 @@ pub(crate) fn bind_int64(
     stmt: *mut sqlite3_stmt,
     index: i32,
     value: i64,
-) -> Result<(), SqliteError> {
+) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_bind_int64(stmt, index as c_int, value) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -254,7 +261,7 @@ pub(crate) fn bind_double(
     stmt: *mut sqlite3_stmt,
     index: i32,
     value: f64,
-) -> Result<(), SqliteError> {
+) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_bind_double(stmt, index as c_int, value) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -265,7 +272,10 @@ pub(crate) fn bind_double(
 }
 
 /// Wrapper around [`sqlite3_bind_null`].
-pub(crate) fn bind_null(stmt: *mut sqlite3_stmt, index: i32) -> Result<(), SqliteError> {
+pub(crate) fn bind_null(
+    stmt: *mut sqlite3_stmt,
+    index: i32,
+) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_bind_null(stmt, index as c_int) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -306,7 +316,7 @@ pub(crate) fn clear_bindings(stmt: *mut sqlite3_stmt) {
 }
 
 /// Wrapper around [`sqlite3_reset`].
-pub(crate) fn reset(stmt: *mut sqlite3_stmt) -> Result<(), SqliteError> {
+pub(crate) fn reset(stmt: *mut sqlite3_stmt) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_reset(stmt) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())
@@ -317,7 +327,7 @@ pub(crate) fn reset(stmt: *mut sqlite3_stmt) -> Result<(), SqliteError> {
 }
 
 /// Wrapper around [`sqlite3_step`].
-pub(crate) fn step(stmt: *mut sqlite3_stmt) -> Result<i32, SqliteError> {
+pub(crate) fn step(stmt: *mut sqlite3_stmt) -> std::result::Result<i32, SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_step(stmt) };
     if rc == ffi_sys::SQLITE_ROW
         || rc == ffi_sys::SQLITE_DONE
@@ -335,7 +345,7 @@ pub(crate) fn step(stmt: *mut sqlite3_stmt) -> Result<i32, SqliteError> {
 }
 
 /// Wrapper around [`sqlite3_finalize`].
-pub(crate) fn finalize(stmt: *mut sqlite3_stmt) -> Result<(), SqliteError> {
+pub(crate) fn finalize(stmt: *mut sqlite3_stmt) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_finalize(stmt) };
     if rc == ffi_sys::SQLITE_OK {
         Ok(())

--- a/crates/musq/src/sqlite/statement/compound.rs
+++ b/crates/musq/src/sqlite/statement/compound.rs
@@ -12,7 +12,7 @@ use libsqlite3_sys::{SQLITE_PREPARE_PERSISTENT, sqlite3, sqlite3_stmt};
 
 use crate::{
     Column, SqliteDataType,
-    error::Error,
+    error::{Error, Result},
     sqlite::{
         connection::ConnectionHandle,
         error::{ExtendedErrCode, PrimaryErrCode},
@@ -53,7 +53,7 @@ pub struct PreparedStatement<'a> {
 }
 
 impl CompoundStatement {
-    pub(crate) fn new(mut query: &str) -> Result<Self, Error> {
+    pub(crate) fn new(mut query: &str) -> Result<Self> {
         query = query.trim();
 
         if query.len() > i32::MAX as usize {
@@ -75,7 +75,7 @@ impl CompoundStatement {
     pub(crate) fn prepare_next(
         &mut self,
         conn: &mut ConnectionHandle,
-    ) -> Result<Option<PreparedStatement<'_>>, Error> {
+    ) -> Result<Option<PreparedStatement<'_>>> {
         // increment `self.index` up to `self.handles.len()`
         self.index = self
             .index
@@ -134,7 +134,7 @@ impl CompoundStatement {
             })
     }
 
-    pub fn reset(&mut self) -> Result<(), Error> {
+    pub fn reset(&mut self) -> Result<()> {
         self.index = None;
 
         for handle in self.handles.iter_mut() {
@@ -147,7 +147,7 @@ impl CompoundStatement {
 }
 
 /// Prepare all statements in the given query.
-fn prepare_all(conn: *mut sqlite3, query: &mut Bytes) -> Result<Option<StatementHandle>, Error> {
+fn prepare_all(conn: *mut sqlite3, query: &mut Bytes) -> Result<Option<StatementHandle>> {
     let flags = SQLITE_PREPARE_PERSISTENT;
 
     while !query.is_empty() {

--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -53,7 +53,7 @@ impl StatementHandle {
         unsafe { ffi::changes(self.db_handle()) as u64 }
     }
 
-    pub(crate) fn column_name(&self, index: usize) -> Result<String, SqliteError> {
+    pub(crate) fn column_name(&self, index: usize) -> std::result::Result<String, SqliteError> {
         // https://sqlite.org/c3ref/column_name.html
         let name = ffi::column_name(self.0.as_ptr(), index as i32);
         if name.is_null() {
@@ -106,7 +106,7 @@ impl StatementHandle {
     // Binding Values To Prepared Statements
     // https://www.sqlite.org/c3ref/bind_blob.html
 
-    pub(crate) fn bind_blob(&self, index: usize, v: &[u8]) -> Result<(), SqliteError> {
+    pub(crate) fn bind_blob(&self, index: usize, v: &[u8]) -> std::result::Result<(), SqliteError> {
         ffi::bind_blob64(
             self.0.as_ptr(),
             index as i32,
@@ -115,7 +115,7 @@ impl StatementHandle {
         )
     }
 
-    pub(crate) fn bind_text(&self, index: usize, v: &str) -> Result<(), SqliteError> {
+    pub(crate) fn bind_text(&self, index: usize, v: &str) -> std::result::Result<(), SqliteError> {
         ffi::bind_text64(
             self.0.as_ptr(),
             index as i32,
@@ -124,19 +124,19 @@ impl StatementHandle {
         )
     }
 
-    pub(crate) fn bind_int(&self, index: usize, v: i32) -> Result<(), SqliteError> {
+    pub(crate) fn bind_int(&self, index: usize, v: i32) -> std::result::Result<(), SqliteError> {
         ffi::bind_int(self.0.as_ptr(), index as i32, v)
     }
 
-    pub(crate) fn bind_int64(&self, index: usize, v: i64) -> Result<(), SqliteError> {
+    pub(crate) fn bind_int64(&self, index: usize, v: i64) -> std::result::Result<(), SqliteError> {
         ffi::bind_int64(self.0.as_ptr(), index as i32, v)
     }
 
-    pub(crate) fn bind_double(&self, index: usize, v: f64) -> Result<(), SqliteError> {
+    pub(crate) fn bind_double(&self, index: usize, v: f64) -> std::result::Result<(), SqliteError> {
         ffi::bind_double(self.0.as_ptr(), index as i32, v)
     }
 
-    pub(crate) fn bind_null(&self, index: usize) -> Result<(), SqliteError> {
+    pub(crate) fn bind_null(&self, index: usize) -> std::result::Result<(), SqliteError> {
         ffi::bind_null(self.0.as_ptr(), index as i32)
     }
 
@@ -167,14 +167,14 @@ impl StatementHandle {
         ffi::clear_bindings(self.0.as_ptr());
     }
 
-    pub(crate) fn reset(&mut self) -> Result<(), SqliteError> {
+    pub(crate) fn reset(&mut self) -> std::result::Result<(), SqliteError> {
         // SAFETY: we have exclusive access to the handle
         ffi::reset(self.0.as_ptr())?;
 
         Ok(())
     }
 
-    pub(crate) fn step(&mut self) -> Result<bool, crate::Error> {
+    pub(crate) fn step(&mut self) -> crate::Result<bool> {
         // SAFETY: we have exclusive access to the handle
         loop {
             let rc = ffi::step(self.0.as_ptr()).map_err(crate::Error::from)?;

--- a/crates/musq/src/sqlite/statement/mod.rs
+++ b/crates/musq/src/sqlite/statement/mod.rs
@@ -41,9 +41,7 @@ impl Statement {
         query::query_statement_with(self, arguments)
     }
 
-    pub fn query_as<O>(
-        &self,
-    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send>
+    pub fn query_as<O>(&self) -> query::Map<impl FnMut(crate::Row) -> crate::Result<O> + Send>
     where
         O: for<'r> from_row::FromRow<'r> + Send + Unpin,
     {
@@ -53,16 +51,14 @@ impl Statement {
     pub fn query_as_with<'s, O>(
         &'s self,
         arguments: Arguments,
-    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send>
+    ) -> query::Map<impl FnMut(crate::Row) -> crate::Result<O> + Send>
     where
         O: for<'r> from_row::FromRow<'r> + Send + Unpin,
     {
         query::query_statement_as_with(self, arguments)
     }
 
-    pub fn query_scalar<O>(
-        &self,
-    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send>
+    pub fn query_scalar<O>(&self) -> query::Map<impl FnMut(crate::Row) -> crate::Result<O> + Send>
     where
         (O,): for<'r> from_row::FromRow<'r>,
         O: Send + Unpin,
@@ -73,7 +69,7 @@ impl Statement {
     pub fn query_scalar_with<'s, O>(
         &'s self,
         arguments: Arguments,
-    ) -> query::Map<impl FnMut(crate::Row) -> Result<O, crate::Error> + Send>
+    ) -> query::Map<impl FnMut(crate::Row) -> crate::Result<O> + Send>
     where
         (O,): for<'r> from_row::FromRow<'r>,
         O: Send + Unpin,

--- a/crates/musq/src/sqlite/statement/unlock_notify.rs
+++ b/crates/musq/src/sqlite/statement/unlock_notify.rs
@@ -7,7 +7,7 @@ use crate::sqlite::ffi;
 use libsqlite3_sys::{SQLITE_LOCKED, sqlite3, sqlite3_stmt};
 
 use crate::{
-    error::Error,
+    error::{Error, Result},
     sqlite::error::{ExtendedErrCode, PrimaryErrCode, SqliteError},
 };
 
@@ -19,11 +19,7 @@ pub const DEFAULT_MAX_RETRIES: usize = 5;
 // If `stmt` is provided, it will be reset and the call retried when
 // `SQLITE_LOCKED` is returned. The `max_retries` parameter controls how many
 // times to retry this reset before giving up.
-pub fn wait(
-    conn: *mut sqlite3,
-    stmt: Option<*mut sqlite3_stmt>,
-    max_retries: usize,
-) -> Result<(), Error> {
+pub fn wait(conn: *mut sqlite3, stmt: Option<*mut sqlite3_stmt>, max_retries: usize) -> Result<()> {
     let notify = Notify::new();
     let mut attempts = 0;
     loop {

--- a/crates/musq/src/sqlite/type_info.rs
+++ b/crates/musq/src/sqlite/type_info.rs
@@ -72,7 +72,7 @@ impl SqliteDataType {
 impl FromStr for SqliteDataType {
     type Err = crate::Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let original = s.to_owned();
         let s = original.to_ascii_lowercase();
         Ok(match &*s {
@@ -106,7 +106,7 @@ impl FromStr for SqliteDataType {
 }
 
 #[test]
-fn test_data_type_from_str() -> Result<(), crate::Error> {
+fn test_data_type_from_str() -> crate::Result<()> {
     assert_eq!(SqliteDataType::Int, "INT4".parse()?);
 
     assert_eq!(SqliteDataType::Int64, "INT".parse()?);

--- a/crates/musq/src/sqlite/value.rs
+++ b/crates/musq/src/sqlite/value.rs
@@ -18,18 +18,18 @@ pub(crate) enum ValueData {
 }
 
 impl Value {
-    pub fn int(&self) -> Result<i32, DecodeError> {
+    pub fn int(&self) -> std::result::Result<i32, DecodeError> {
         Ok(i32::try_from(self.int64()?)?)
     }
 
-    pub fn int64(&self) -> Result<i64, DecodeError> {
+    pub fn int64(&self) -> std::result::Result<i64, DecodeError> {
         match self.data {
             ValueData::Integer(v) => Ok(v),
             _ => Err(DecodeError::Conversion("not an integer".into())),
         }
     }
 
-    pub fn double(&self) -> Result<f64, DecodeError> {
+    pub fn double(&self) -> std::result::Result<f64, DecodeError> {
         match self.data {
             ValueData::Double(v) => Ok(v),
             ValueData::Integer(v) => Ok(v as f64),
@@ -44,7 +44,7 @@ impl Value {
         }
     }
 
-    pub fn text(&self) -> Result<&str, DecodeError> {
+    pub fn text(&self) -> std::result::Result<&str, DecodeError> {
         match &self.data {
             ValueData::Text(v) => from_utf8(v).map_err(|e| DecodeError::Conversion(e.to_string())),
             _ => Err(DecodeError::Conversion("not text".into())),

--- a/crates/musq/src/transaction.rs
+++ b/crates/musq/src/transaction.rs
@@ -54,7 +54,11 @@ where
 
     /// Aborts this transaction or savepoint.
     pub async fn rollback(&mut self) -> Result<()> {
-        self.connection.as_connection_mut().worker.rollback().await?;
+        self.connection
+            .as_connection_mut()
+            .worker
+            .rollback()
+            .await?;
         self.open = false;
         Ok(())
     }
@@ -114,7 +118,11 @@ where
 {
     fn drop(&mut self) {
         if self.open {
-            self.connection.as_connection_mut().worker.start_rollback().ok();
+            self.connection
+                .as_connection_mut()
+                .worker
+                .start_rollback()
+                .ok();
         }
     }
 }

--- a/crates/musq/src/types/bool.rs
+++ b/crates/musq/src/types/bool.rs
@@ -13,7 +13,7 @@ impl Encode for bool {
 }
 
 impl<'r> Decode<'r> for bool {
-    fn decode(value: &'r Value) -> Result<bool, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<bool, DecodeError> {
         compatible!(
             value,
             SqliteDataType::Bool | SqliteDataType::Int | SqliteDataType::Int64

--- a/crates/musq/src/types/bstr.rs
+++ b/crates/musq/src/types/bstr.rs
@@ -1,6 +1,6 @@
 /// Conversions between `bstr` types and SQL types.
 use crate::{
-    ArgumentValue, Result, SqliteDataType, Value, compatible, decode::Decode, encode::Encode,
+    ArgumentValue, SqliteDataType, Value, compatible, decode::Decode, encode::Encode,
     error::DecodeError,
 };
 
@@ -8,7 +8,7 @@ use crate::{
 pub use bstr::{BStr, BString, ByteSlice};
 
 impl<'r> Decode<'r> for BString {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Blob | SqliteDataType::Text);
         Ok(BString::from(value.blob().to_owned()))
     }

--- a/crates/musq/src/types/bytes.rs
+++ b/crates/musq/src/types/bytes.rs
@@ -12,7 +12,7 @@ impl Encode for &[u8] {
 }
 
 impl<'r> Decode<'r> for &'r [u8] {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Blob | SqliteDataType::Text);
         Ok(value.blob())
     }
@@ -25,7 +25,7 @@ impl Encode for Vec<u8> {
 }
 
 impl<'r> Decode<'r> for Vec<u8> {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Blob | SqliteDataType::Text);
         Ok(value.blob().to_owned())
     }
@@ -38,7 +38,7 @@ impl Encode for Arc<Vec<u8>> {
 }
 
 impl<'r> Decode<'r> for Arc<Vec<u8>> {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Blob | SqliteDataType::Text);
         Ok(Arc::new(value.blob().to_owned()))
     }

--- a/crates/musq/src/types/float.rs
+++ b/crates/musq/src/types/float.rs
@@ -13,7 +13,7 @@ impl Encode for f32 {
 }
 
 impl<'r> Decode<'r> for f32 {
-    fn decode(value: &'r Value) -> Result<f32, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<f32, DecodeError> {
         compatible!(value, SqliteDataType::Float);
         Ok(value.double()? as f32)
     }
@@ -26,7 +26,7 @@ impl Encode for f64 {
 }
 
 impl<'r> Decode<'r> for f64 {
-    fn decode(value: &'r Value) -> Result<f64, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<f64, DecodeError> {
         compatible!(value, SqliteDataType::Float);
         value.double()
     }

--- a/crates/musq/src/types/int.rs
+++ b/crates/musq/src/types/int.rs
@@ -13,7 +13,7 @@ impl Encode for i8 {
 }
 
 impl<'r> Decode<'r> for i8 {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
         let v: i32 = value.int()?;
         Ok(v.try_into()?)
@@ -27,7 +27,7 @@ impl Encode for i16 {
 }
 
 impl<'r> Decode<'r> for i16 {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
         let v: i32 = value.int()?;
         Ok(v.try_into()?)
@@ -41,7 +41,7 @@ impl Encode for i32 {
 }
 
 impl<'r> Decode<'r> for i32 {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
         value.int()
     }
@@ -54,7 +54,7 @@ impl Encode for i64 {
 }
 
 impl<'r> Decode<'r> for i64 {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
         value.int64()
     }

--- a/crates/musq/src/types/str.rs
+++ b/crates/musq/src/types/str.rs
@@ -12,7 +12,7 @@ impl Encode for &str {
 }
 
 impl<'r> Decode<'r> for &'r str {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Text);
         value.text()
     }
@@ -25,7 +25,7 @@ impl Encode for String {
 }
 
 impl<'r> Decode<'r> for String {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Text);
         value.text().map(ToOwned::to_owned)
     }
@@ -38,7 +38,7 @@ impl Encode for Arc<String> {
 }
 
 impl<'r> Decode<'r> for Arc<String> {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Text);
         value.text().map(|x| Arc::new(x.to_owned()))
     }

--- a/crates/musq/src/types/time.rs
+++ b/crates/musq/src/types/time.rs
@@ -37,26 +37,26 @@ impl Encode for Time {
 }
 
 impl<'r> Decode<'r> for OffsetDateTime {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         decode_offset_datetime(value)
     }
 }
 
 impl<'r> Decode<'r> for PrimitiveDateTime {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         decode_datetime(value)
     }
 }
 
 impl<'r> Decode<'r> for Date {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         Date::parse(value.text()?, &fd!("[year]-[month]-[day]"))
             .map_err(|e| DecodeError::Conversion(e.to_string()))
     }
 }
 
 impl<'r> Decode<'r> for Time {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         let value = value.text()?;
 
         let sqlite_time_formats = &[
@@ -75,7 +75,7 @@ impl<'r> Decode<'r> for Time {
     }
 }
 
-fn decode_offset_datetime(value: &Value) -> Result<OffsetDateTime, DecodeError> {
+fn decode_offset_datetime(value: &Value) -> std::result::Result<OffsetDateTime, DecodeError> {
     compatible!(
         value,
         SqliteDataType::Text | SqliteDataType::Int64 | SqliteDataType::Int
@@ -113,7 +113,7 @@ fn decode_offset_datetime_from_text(value: &str) -> Option<OffsetDateTime> {
     None
 }
 
-fn decode_datetime(value: &Value) -> Result<PrimitiveDateTime, DecodeError> {
+fn decode_datetime(value: &Value) -> std::result::Result<PrimitiveDateTime, DecodeError> {
     compatible!(
         value,
         SqliteDataType::Text | SqliteDataType::Int64 | SqliteDataType::Int

--- a/crates/musq/src/types/uint.rs
+++ b/crates/musq/src/types/uint.rs
@@ -13,7 +13,7 @@ impl Encode for u8 {
 }
 
 impl<'r> Decode<'r> for u8 {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
         let v: i32 = value.int()?;
         Ok(v.try_into()?)
@@ -27,7 +27,7 @@ impl Encode for u16 {
 }
 
 impl<'r> Decode<'r> for u16 {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
         let v: i32 = value.int()?;
         Ok(v.try_into()?)
@@ -41,7 +41,7 @@ impl Encode for u32 {
 }
 
 impl<'r> Decode<'r> for u32 {
-    fn decode(value: &'r Value) -> Result<Self, DecodeError> {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
         compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
         Ok(value.int64()?.try_into()?)
     }

--- a/crates/musq/src/ustr.rs
+++ b/crates/musq/src/ustr.rs
@@ -71,7 +71,9 @@ impl Display for UStr {
 // manual impls because otherwise things get a little screwy with lifetimes
 
 impl<'de> serde::Deserialize<'de> for UStr {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as serde::Deserializer<'de>>::Error>
+    fn deserialize<D>(
+        deserializer: D,
+    ) -> std::result::Result<Self, <D as serde::Deserializer<'de>>::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -83,7 +85,7 @@ impl serde::Serialize for UStr {
     fn serialize<S>(
         &self,
         serializer: S,
-    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    ) -> std::result::Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
     where
         S: serde::Serializer,
     {

--- a/crates/musq/tests/error.rs
+++ b/crates/musq/tests/error.rs
@@ -1,4 +1,4 @@
-use musq::{Error, ExtendedErrCode, PrimaryErrCode, query};
+use musq::{ExtendedErrCode, PrimaryErrCode, Result, query};
 use musq_test::tdb;
 
 #[tokio::test]
@@ -6,7 +6,7 @@ async fn it_fails_with_unique_violation() -> anyhow::Result<()> {
     let mut conn = tdb().await?;
     let mut tx = conn.begin().await?;
 
-    let res: Result<_, Error> = query("INSERT INTO tweet VALUES (1, 'Foo', true, 1);")
+    let res: Result<_> = query("INSERT INTO tweet VALUES (1, 'Foo', true, 1);")
         .execute(&mut tx)
         .await;
     let err = res.unwrap_err();
@@ -24,7 +24,7 @@ async fn it_fails_with_foreign_key_violation() -> anyhow::Result<()> {
     let mut conn = tdb().await?;
     let mut tx = conn.begin().await?;
 
-    let res: Result<_, Error> =
+    let res: Result<_> =
         query("INSERT INTO tweet_reply (id, tweet_id, text) VALUES (2, 2, 'Reply!');")
             .execute(&mut tx)
             .await;
@@ -43,7 +43,7 @@ async fn it_fails_with_not_null_violation() -> anyhow::Result<()> {
     let mut conn = tdb().await?;
     let mut tx = conn.begin().await?;
 
-    let res: Result<_, Error> = query("INSERT INTO tweet (text) VALUES (null);")
+    let res: Result<_> = query("INSERT INTO tweet (text) VALUES (null);")
         .execute(&mut tx)
         .await;
     let err = res.unwrap_err();
@@ -61,7 +61,7 @@ async fn it_fails_with_check_violation() -> anyhow::Result<()> {
     let mut conn = tdb().await?;
     let mut tx = conn.begin().await?;
 
-    let res: Result<_, Error> = query("INSERT INTO products VALUES (1, 'Product 1', 0);")
+    let res: Result<_> = query("INSERT INTO products VALUES (1, 'Product 1', 0);")
         .execute(&mut tx)
         .await;
     let err = res.unwrap_err();


### PR DESCRIPTION
## Summary
- update `error::Result` alias to use a fixed `Error`
- adjust imports and generics for the new alias
- use `std::result::Result` where other error types are required

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c5dbaff3c8333aef94cf71c2363d8