### PR TITLE
Fix error capture before closing DB handle

### DIFF
--- a/crates/musq/src/sqlite/connection/establish.rs
+++ b/crates/musq/src/sqlite/connection/establish.rs
@@ -114,17 +114,17 @@ impl EstablishParams {
         // <https://www.sqlite.org/c3ref/open.html>
         let open_res = ffi::open_v2(self.filename.as_ptr(), &mut handle, self.open_flags, null());
 
+        if let Err(e) = open_res {
+            // handle is already closed inside `open_v2`
+            return Err(Error::Sqlite(e));
+        }
+
         if handle.is_null() {
             // Failed to allocate memory
             return Err(Error::Io(io::Error::new(
                 io::ErrorKind::OutOfMemory,
                 "SQLite is unable to allocate memory to hold the sqlite3 object",
             )));
-        }
-
-        if let Err(e) = open_res {
-            // handle may already be closed inside `open_v2`
-            return Err(Error::Sqlite(e));
         }
 
         // SAFE: tested for NULL just above and open_v2 succeeded

--- a/crates/musq/src/sqlite/ffi.rs
+++ b/crates/musq/src/sqlite/ffi.rs
@@ -37,12 +37,17 @@ pub(crate) fn open_v2(
                 message: "sqlite3_open_v2 failed".into(),
             })
         } else {
+            // capture the error before closing the handle
+            let err = SqliteError::new(db);
+
             // SAFETY: db is valid when rc != SQLITE_OK and not null
             unsafe {
                 ffi_sys::sqlite3_close(db);
+                // prevent dangling pointer in the caller
+                *handle = std::ptr::null_mut();
             }
 
-            Err(SqliteError::new(db))
+            Err(err)
         }
     }
 }

--- a/crates/musq/tests/error.rs
+++ b/crates/musq/tests/error.rs
@@ -86,6 +86,7 @@ async fn it_fails_to_open() -> anyhow::Result<()> {
     let res = Connection::connect_with(&options).await;
 
     let err = res.unwrap_err();
+    println!("error: {err:?}");
     assert!(err.into_sqlite_error().is_some());
 
     Ok(())


### PR DESCRIPTION
## Summary
- capture SQLite error information before closing the handle in `open_v2`
- update connection establishment to expect closed handle from `open_v2`
- print error in `it_fails_to_open` test for clarity

## Testing
- `cargo clippy --workspace --tests -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_687c6091d9e48333b4f609218eba06c0