### PR TITLE
Log panics from progress handler

### DIFF
--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -358,7 +358,21 @@ where
             let callback: *mut F = callback.cast::<F>();
             (*callback)()
         });
-        i32::from(!r.unwrap_or_default())
+
+        match r {
+            Ok(res) => i32::from(!res),
+            Err(err) => {
+                if let Some(msg) = err.downcast_ref::<&str>() {
+                    tracing::error!("progress handler panicked: {}", msg);
+                } else if let Some(msg) = err.downcast_ref::<String>() {
+                    tracing::error!("progress handler panicked: {}", msg);
+                } else {
+                    tracing::error!("progress handler panicked");
+                }
+
+                i32::from(!bool::default())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- log panics if the progress handler unwinds

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c60fb9ce08333bdb2701d786422d9