### PR TITLE
Enforce ?0 as protocol error

### DIFF
--- a/crates/musq/src/sqlite/arguments.rs
+++ b/crates/musq/src/sqlite/arguments.rs
@@ -5,8 +5,16 @@ use atoi::atoi;
 
 pub(crate) fn parse_question_param(name: &str) -> Result<usize, Error> {
     let rest = name.trim_start_matches('?');
-    atoi::<usize>(rest.as_bytes())
-        .ok_or_else(|| Error::Protocol(format!("invalid numeric SQL parameter: {name}")))
+    let num = atoi::<usize>(rest.as_bytes())
+        .ok_or_else(|| Error::Protocol(format!("invalid numeric SQL parameter: {name}")))?;
+
+    if num == 0 {
+        return Err(Error::Protocol(format!(
+            "invalid numeric SQL parameter: {name}"
+        )));
+    }
+
+    Ok(num)
 }
 
 #[derive(Debug)]
@@ -152,6 +160,15 @@ mod tests {
         let err = parse_question_param("?foo").unwrap_err();
         match err {
             Error::Protocol(msg) => assert!(msg.contains("?foo")),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_question_param_zero() {
+        let err = parse_question_param("?0").unwrap_err();
+        match err {
+            Error::Protocol(msg) => assert!(msg.contains("?0")),
             other => panic!("unexpected error: {other:?}"),
         }
     }


### PR DESCRIPTION
## Summary
- reject zero-position numeric parameters
- test parsing of `?0`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c60cd385883339608e75e06b25ed8