### PR TITLE
Fix Map bind docs

### DIFF
--- a/crates/musq/src/query.rs
+++ b/crates/musq/src/query.rs
@@ -20,8 +20,9 @@ pub struct Query {
 /// the return types are changed to reflect the mapping. However, there is no equivalent of
 /// [`Query::execute`] as it doesn't make sense to map the result type and then ignore it.
 ///
-/// [`Query::bind`] is also omitted; stylistically we recommend placing your `.bind()` calls
-/// before `.try_map()`. This is also to prevent adding superfluous binds to the result of
+/// [`Map::bind`] and [`Map::bind_named`] may be used to add parameters after
+/// [`try_map()`]. Stylistically we still recommend placing your `.bind()` calls
+/// before `.try_map()` to avoid adding superfluous binds when using
 /// `query!()` et al.
 #[must_use = "query must be executed to affect database"]
 pub struct Map<F> {


### PR DESCRIPTION
## Summary
- document that `Map` allows binding after `try_map`

## Testing
- `cargo clippy -q`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_687c666cdec083338f22878ae6859997