### PR TITLE
Adjust macro visibility

### DIFF
--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -10,6 +10,7 @@ pub mod encode;
 mod error;
 mod executor;
 mod from_row;
+#[macro_use]
 mod logger;
 mod musq;
 pub mod pool;
@@ -18,6 +19,7 @@ mod query_result;
 mod row;
 mod statement_cache;
 mod transaction;
+#[macro_use]
 pub mod types;
 
 pub use crate::{

--- a/crates/musq/src/logger.rs
+++ b/crates/musq/src/logger.rs
@@ -39,7 +39,6 @@ impl LogSettings {
 // Yes these look silly. `tracing` doesn't currently support dynamic levels
 // https://github.com/tokio-rs/tracing/issues/372
 #[doc(hidden)]
-#[macro_export]
 macro_rules! private_tracing_dynamic_enabled {
     (target: $target:expr, $level:expr) => {{
         use ::tracing::Level;
@@ -58,7 +57,6 @@ macro_rules! private_tracing_dynamic_enabled {
 }
 
 #[doc(hidden)]
-#[macro_export]
 macro_rules! private_tracing_dynamic_event {
     (target: $target:expr, $level:expr, $($args:tt)*) => {{
         use ::tracing::Level;

--- a/crates/musq/src/types/bool.rs
+++ b/crates/musq/src/types/bool.rs
@@ -1,5 +1,4 @@
 use crate::{
-    compatible,
     decode::Decode,
     encode::Encode,
     error::DecodeError,

--- a/crates/musq/src/types/bstr.rs
+++ b/crates/musq/src/types/bstr.rs
@@ -1,7 +1,6 @@
 /// Conversions between `bstr` types and SQL types.
 use crate::{
-    ArgumentValue, SqliteDataType, Value, compatible, decode::Decode, encode::Encode,
-    error::DecodeError,
+    ArgumentValue, SqliteDataType, Value, decode::Decode, encode::Encode, error::DecodeError,
 };
 
 #[doc(no_inline)]

--- a/crates/musq/src/types/bytes.rs
+++ b/crates/musq/src/types/bytes.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    ArgumentValue, SqliteDataType, Value, compatible, decode::Decode, encode::Encode,
-    error::DecodeError,
+    ArgumentValue, SqliteDataType, Value, decode::Decode, encode::Encode, error::DecodeError,
 };
 
 impl Encode for &[u8] {

--- a/crates/musq/src/types/float.rs
+++ b/crates/musq/src/types/float.rs
@@ -1,5 +1,4 @@
 use crate::{
-    compatible,
     decode::Decode,
     encode::Encode,
     error::DecodeError,

--- a/crates/musq/src/types/int.rs
+++ b/crates/musq/src/types/int.rs
@@ -1,5 +1,4 @@
 use crate::{
-    compatible,
     decode::Decode,
     encode::Encode,
     error::DecodeError,

--- a/crates/musq/src/types/mod.rs
+++ b/crates/musq/src/types/mod.rs
@@ -38,6 +38,16 @@
 //!
 //! `Option<T>` is supported where `T` implements `Encode` or `Decode`. An `Option<T>` represents a potentially `NULL`
 //! value from SQLite.
+
+macro_rules! compatible {
+    ($x:expr, $($y:path)|+) => {
+        let t = $x.type_info();
+        if !t.is_null() && !matches!(t, $($y)|+) {
+            return Err(DecodeError::DataType(t))
+        }
+    };
+}
+
 pub mod bstr;
 pub mod time;
 
@@ -47,13 +57,3 @@ mod float;
 mod int;
 mod str;
 mod uint;
-
-#[macro_export]
-macro_rules! compatible {
-    ($x:expr, $($y:path)|+) => {
-        let t = $x.type_info();
-        if !t.is_null() && !matches!(t, $($y)|+) {
-            return Err(DecodeError::DataType(t))
-        }
-    };
-}

--- a/crates/musq/src/types/str.rs
+++ b/crates/musq/src/types/str.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    ArgumentValue, SqliteDataType, Value, compatible, decode::Decode, encode::Encode,
-    error::DecodeError,
+    ArgumentValue, SqliteDataType, Value, decode::Decode, encode::Encode, error::DecodeError,
 };
 
 impl Encode for &str {

--- a/crates/musq/src/types/time.rs
+++ b/crates/musq/src/types/time.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Value, compatible,
+    Value,
     decode::Decode,
     encode::Encode,
     error::DecodeError,

--- a/crates/musq/src/types/uint.rs
+++ b/crates/musq/src/types/uint.rs
@@ -1,5 +1,4 @@
 use crate::{
-    compatible,
     decode::Decode,
     encode::Encode,
     error::DecodeError,


### PR DESCRIPTION
## Summary
- make logger and type macros internal
- expose macros inside lib.rs via `#[macro_use]`
- call `compatible!` without importing

## Testing
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`


------
https://chatgpt.com/codex/tasks/task_e_687c6bea4f408333a067db8e434b2462