### PR TITLE
Add retry limits to SQLite exec and step

### DIFF
--- a/crates/musq/src/sqlite/connection/handle.rs
+++ b/crates/musq/src/sqlite/connection/handle.rs
@@ -6,7 +6,7 @@ use crate::sqlite::ffi;
 
 use crate::{
     Error,
-    sqlite::{error::ExtendedErrCode, statement::unlock_notify},
+    sqlite::{DEFAULT_MAX_RETRIES, error::ExtendedErrCode, statement::unlock_notify},
 };
 
 /// Managed handle to the raw SQLite3 database handle.
@@ -49,11 +49,16 @@ impl ConnectionHandle {
             CString::new(query).map_err(|_| Error::Protocol("query contains nul bytes".into()))?;
 
         // SAFETY: we have exclusive access to the database handle
+        let mut attempts = 0;
         loop {
             match ffi::exec(self.as_ptr(), query.as_ptr()) {
                 Ok(()) => return Ok(()),
                 Err(e) if e.extended == ExtendedErrCode::LockedSharedCache => {
-                    unlock_notify::wait(self.as_ptr(), None, unlock_notify::DEFAULT_MAX_RETRIES)?;
+                    if attempts >= DEFAULT_MAX_RETRIES {
+                        return Err(Error::UnlockNotify);
+                    }
+                    attempts += 1;
+                    unlock_notify::wait(self.as_ptr(), None)?;
                 }
                 Err(e) => return Err(e.into()),
             }

--- a/crates/musq/src/sqlite/mod.rs
+++ b/crates/musq/src/sqlite/mod.rs
@@ -12,3 +12,11 @@ mod ffi;
 pub mod statement;
 mod type_info;
 pub(crate) mod value;
+
+/// Default number of times [`unlock_notify::wait`] is allowed to retry when a
+/// statement is reset due to `SQLITE_LOCKED`.
+///
+/// [`ConnectionHandle::exec`] and [`StatementHandle::step`] use this constant to
+/// limit how many unlock notification attempts will be made before returning
+/// [`Error::UnlockNotify`].
+pub const DEFAULT_MAX_RETRIES: usize = 5;

--- a/crates/musq/src/sqlite/statement/compound.rs
+++ b/crates/musq/src/sqlite/statement/compound.rs
@@ -172,7 +172,7 @@ fn prepare_all(conn: *mut sqlite3, query: &mut Bytes) -> Result<Option<Statement
                     if e.extended == ExtendedErrCode::LockedSharedCache
                         || e.primary == PrimaryErrCode::Busy =>
                 {
-                    unlock_notify::wait(conn, None, unlock_notify::DEFAULT_MAX_RETRIES)?;
+                    unlock_notify::wait(conn, None)?;
                 }
                 Err(e) => return Err(e.into()),
             }

--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -10,6 +10,7 @@ use libsqlite3_sys::{
 };
 
 use crate::sqlite::{
+    DEFAULT_MAX_RETRIES,
     error::{ExtendedErrCode, PrimaryErrCode, SqliteError},
     ffi,
 };
@@ -176,6 +177,7 @@ impl StatementHandle {
 
     pub(crate) fn step(&mut self) -> Result<bool, crate::Error> {
         // SAFETY: we have exclusive access to the handle
+        let mut attempts = 0;
         loop {
             let rc = ffi::step(self.0.as_ptr()).map_err(crate::Error::from)?;
             match rc {
@@ -185,11 +187,11 @@ impl StatementHandle {
                 SQLITE_LOCKED_SHAREDCACHE | libsqlite3_sys::SQLITE_LOCKED => {
                     // The shared cache is locked by another connection. Wait for unlock
                     // notification and try again.
-                    unlock_notify::wait(
-                        unsafe { self.db_handle() },
-                        Some(self.0.as_ptr()),
-                        unlock_notify::DEFAULT_MAX_RETRIES,
-                    )?;
+                    if attempts >= DEFAULT_MAX_RETRIES {
+                        return Err(crate::Error::UnlockNotify);
+                    }
+                    attempts += 1;
+                    unlock_notify::wait(unsafe { self.db_handle() }, Some(self.0.as_ptr()))?;
                     // Need to reset the handle after the unlock
                     // (https://www.sqlite.org/unlock_notify.html)
                     loop {
@@ -203,7 +205,6 @@ impl StatementHandle {
                                 unlock_notify::wait(
                                     unsafe { self.db_handle() },
                                     Some(self.0.as_ptr()),
-                                    unlock_notify::DEFAULT_MAX_RETRIES,
                                 )?;
                                 continue;
                             }
@@ -214,11 +215,11 @@ impl StatementHandle {
                 libsqlite3_sys::SQLITE_BUSY => {
                     // Another connection holds a lock that prevented the step from
                     // completing. Wait for an unlock notification and retry.
-                    unlock_notify::wait(
-                        unsafe { self.db_handle() },
-                        Some(self.0.as_ptr()),
-                        unlock_notify::DEFAULT_MAX_RETRIES,
-                    )?;
+                    if attempts >= DEFAULT_MAX_RETRIES {
+                        return Err(crate::Error::UnlockNotify);
+                    }
+                    attempts += 1;
+                    unlock_notify::wait(unsafe { self.db_handle() }, Some(self.0.as_ptr()))?;
                     loop {
                         match ffi::reset(self.0.as_ptr()) {
                             Ok(()) => break,
@@ -230,7 +231,6 @@ impl StatementHandle {
                                 unlock_notify::wait(
                                     unsafe { self.db_handle() },
                                     Some(self.0.as_ptr()),
-                                    unlock_notify::DEFAULT_MAX_RETRIES,
                                 )?;
                                 continue;
                             }

--- a/crates/musq/src/sqlite/statement/unlock_notify.rs
+++ b/crates/musq/src/sqlite/statement/unlock_notify.rs
@@ -3,6 +3,7 @@ use std::ffi::c_void;
 use std::slice;
 use std::sync::{Condvar, Mutex};
 
+use crate::sqlite::DEFAULT_MAX_RETRIES;
 use crate::sqlite::ffi;
 use libsqlite3_sys::{SQLITE_LOCKED, sqlite3, sqlite3_stmt};
 
@@ -11,19 +12,10 @@ use crate::{
     sqlite::error::{ExtendedErrCode, PrimaryErrCode, SqliteError},
 };
 
-/// Default number of times [`wait`] will retry when a statement is reset due to
-/// `SQLITE_LOCKED`.
-pub const DEFAULT_MAX_RETRIES: usize = 5;
-
 // Wait for unlock notification (https://www.sqlite.org/unlock_notify.html)
 // If `stmt` is provided, it will be reset and the call retried when
-// `SQLITE_LOCKED` is returned. The `max_retries` parameter controls how many
-// times to retry this reset before giving up.
-pub fn wait(
-    conn: *mut sqlite3,
-    stmt: Option<*mut sqlite3_stmt>,
-    max_retries: usize,
-) -> Result<(), Error> {
+// `SQLITE_LOCKED` is returned.
+pub fn wait(conn: *mut sqlite3, stmt: Option<*mut sqlite3_stmt>) -> Result<(), Error> {
     let notify = Notify::new();
     let mut attempts = 0;
     loop {
@@ -38,7 +30,7 @@ pub fn wait(
                     let _ = ffi::reset(stmt);
                     attempts += 1;
 
-                    if attempts > max_retries {
+                    if attempts > DEFAULT_MAX_RETRIES {
                         return Err(Error::UnlockNotify);
                     }
 


### PR DESCRIPTION
## Summary
- track attempt counts in `ConnectionHandle::exec` and `StatementHandle::step`
- return `Error::UnlockNotify` when the retry limit is exceeded
- remove unlock notify retry parameter and use new global constant
- import `DEFAULT_MAX_RETRIES` directly and document its broader use

## Testing
- `cargo clippy --all-targets --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687c60eea6e48333a9617e2a28d3557b