### PR TITLE
Unify Value handling

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -21,7 +21,10 @@ async fn pool() -> musq::Pool {
         .open_in_memory()
         .await
         .unwrap();
-    musq::query(BENCH_SCHEMA).execute(&mut pool.acquire().await.unwrap()).await.unwrap();
+    musq::query(BENCH_SCHEMA)
+        .execute(&mut pool.acquire().await.unwrap())
+        .await
+        .unwrap();
     pool
 }
 

--- a/crates/musq-macros/src/encode.rs
+++ b/crates/musq-macros/src/encode.rs
@@ -29,7 +29,7 @@ fn expand_enum(
         #[automatically_derived]
         impl musq::encode::Encode for #ident
         {
-            fn encode(self) -> musq::ArgumentValue {
+            fn encode(self) -> musq::Value {
                 let val = match self {
                     #(#value_arms)*
                 };
@@ -58,7 +58,7 @@ fn expand_repr_enum(
         where
             #repr: musq::encode::Encode,
         {
-            fn encode(self) -> musq::ArgumentValue {
+            fn encode(self) -> musq::Value {
                 let value = match self {
                     #(#values)*
                 };
@@ -94,7 +94,7 @@ fn expand_struct(
         impl #impl_generics musq::encode::Encode for #ident #ty_generics
         #where_clause
         {
-            fn encode(self) -> musq::ArgumentValue {
+            fn encode(self) -> musq::Value {
                 <#ty as musq::encode::Encode>::encode(self.0)
             }
         }

--- a/crates/musq-macros/src/json.rs
+++ b/crates/musq-macros/src/json.rs
@@ -21,12 +21,12 @@ pub fn expand_json(input: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote!(
         impl #impl_generics musq::encode::Encode for #ident #ty_generics #where_clause {
-            fn encode(self) -> musq::ArgumentValue {
+            fn encode(self) -> musq::Value {
                 let v = serde_json::to_string(&self).expect(
                          "failed to encode value as JSON; the most likely cause is \
                          attempting to serialize a map with a non-string key type"
                 );
-                musq::ArgumentValue::Text(v)
+                musq::Value::Text(v.into_bytes(), None)
             }
         }
 

--- a/crates/musq/src/encode.rs
+++ b/crates/musq/src/encode.rs
@@ -1,12 +1,12 @@
 //! Provides [`Encode`] for encoding values for the database.
-use crate::ArgumentValue;
+use crate::Value;
 
 /// Encode a single value to be sent to the database.
 pub trait Encode {
     /// Writes the value of `self` into `buf` in the expected format for the database, consuming the value. Encoders are
     /// implemented for reference counted types where a shift in ownership is not wanted.
     #[must_use]
-    fn encode(self) -> ArgumentValue
+    fn encode(self) -> Value
     where
         Self: Sized;
 }
@@ -15,11 +15,11 @@ impl<T> Encode for Option<T>
 where
     T: Encode,
 {
-    fn encode(self) -> ArgumentValue {
+    fn encode(self) -> Value {
         if let Some(v) = self {
             v.encode()
         } else {
-            ArgumentValue::Null
+            Value::Null(None)
         }
     }
 }

--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::{
     query_result::QueryResult,
     row::Row,
     sqlite::{
-        ArgumentValue, Arguments, Connection, SqliteDataType, SqliteError, Statement, Value,
+        Arguments, Connection, SqliteDataType, SqliteError, Statement, Value,
         error::{ExtendedErrCode, PrimaryErrCode},
     },
     transaction::Transaction,

--- a/crates/musq/src/pool/connection_like.rs
+++ b/crates/musq/src/pool/connection_like.rs
@@ -37,5 +37,3 @@ where
         (**self).as_connection_mut()
     }
 }
-
-

--- a/crates/musq/src/row.rs
+++ b/crates/musq/src/row.rs
@@ -4,7 +4,7 @@ use crate::{
     Column, Result,
     decode::Decode,
     error::Error,
-    sqlite::{Value, statement::StatementHandle},
+    sqlite::{SqliteDataType, Value, statement::StatementHandle},
     ustr::UStr,
 };
 
@@ -31,7 +31,6 @@ impl Row {
         columns: &Arc<Vec<Column>>,
         column_names: &Arc<HashMap<UStr, usize>>,
     ) -> Self {
-        use crate::sqlite::value::ValueData;
         use libsqlite3_sys::SQLITE_NULL;
 
         let size = statement.column_count();
@@ -39,10 +38,14 @@ impl Row {
 
         for i in 0..size {
             let code = statement.column_type(i);
-            let data = match code {
-                SQLITE_NULL => ValueData::Null,
-                libsqlite3_sys::SQLITE_INTEGER => ValueData::Integer(statement.column_int64(i)),
-                libsqlite3_sys::SQLITE_FLOAT => ValueData::Double(statement.column_double(i)),
+            let ti = match columns[i].type_info {
+                SqliteDataType::Null => None,
+                other => Some(other),
+            };
+            let value = match code {
+                SQLITE_NULL => Value::Null(ti),
+                libsqlite3_sys::SQLITE_INTEGER => Value::Integer(statement.column_int64(i), ti),
+                libsqlite3_sys::SQLITE_FLOAT => Value::Double(statement.column_double(i), ti),
                 libsqlite3_sys::SQLITE_TEXT => {
                     let len = statement.column_bytes(i) as usize;
                     let ptr = statement.column_blob(i) as *const u8;
@@ -51,25 +54,22 @@ impl Row {
                     } else {
                         unsafe { std::slice::from_raw_parts(ptr, len) }
                     };
-                    ValueData::Text(slice.to_vec())
+                    Value::Text(slice.to_vec(), ti)
                 }
                 libsqlite3_sys::SQLITE_BLOB => {
                     let len = statement.column_bytes(i) as usize;
                     if len == 0 {
-                        ValueData::Blob(Vec::new())
+                        Value::Blob(Vec::new(), ti)
                     } else {
                         let ptr = statement.column_blob(i) as *const u8;
                         let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
-                        ValueData::Blob(slice.to_vec())
+                        Value::Blob(slice.to_vec(), ti)
                     }
                 }
                 _ => unreachable!(),
             };
 
-            values.push(Value {
-                data,
-                type_info: columns[i].type_info,
-            });
+            values.push(value);
         }
 
         Self {

--- a/crates/musq/src/sqlite/arguments.rs
+++ b/crates/musq/src/sqlite/arguments.rs
@@ -1,4 +1,8 @@
-use crate::{Error, Result, encode::Encode, sqlite::statement::StatementHandle};
+use crate::{
+    Error, Result,
+    encode::Encode,
+    sqlite::{Value, statement::StatementHandle},
+};
 use std::collections::HashMap;
 
 use atoi::atoi;
@@ -17,19 +21,9 @@ pub(crate) fn parse_question_param(name: &str) -> Result<usize> {
     Ok(num)
 }
 
-#[derive(Debug)]
-pub enum ArgumentValue {
-    Null,
-    Text(String),
-    Blob(Vec<u8>),
-    Double(f64),
-    Int(i32),
-    Int64(i64),
-}
-
 #[derive(Default, Debug)]
 pub struct Arguments {
-    pub(crate) values: Vec<ArgumentValue>,
+    pub(crate) values: Vec<Value>,
     /// Mapping from named parameters to their argument indices (1-based).
     pub(crate) named: HashMap<String, usize>,
 }
@@ -133,17 +127,16 @@ impl Arguments {
     }
 }
 
-impl ArgumentValue {
+impl Value {
     fn bind(&self, handle: &mut StatementHandle, i: usize) -> Result<()> {
-        use ArgumentValue::*;
+        use Value::*;
 
         match self {
-            Text(v) => handle.bind_text(i, v.as_str())?,
-            Blob(v) => handle.bind_blob(i, v.as_slice())?,
-            Int(v) => handle.bind_int(i, *v)?,
-            Int64(v) => handle.bind_int64(i, *v)?,
-            Double(v) => handle.bind_double(i, *v)?,
-            Null => handle.bind_null(i)?,
+            Text(v, _) => handle.bind_text(i, unsafe { std::str::from_utf8_unchecked(v) })?,
+            Blob(v, _) => handle.bind_blob(i, v.as_slice())?,
+            Integer(v, _) => handle.bind_int64(i, *v)?,
+            Double(v, _) => handle.bind_double(i, *v)?,
+            Null(_) => handle.bind_null(i)?,
         }
 
         Ok(())

--- a/crates/musq/src/sqlite/ffi.rs
+++ b/crates/musq/src/sqlite/ffi.rs
@@ -232,6 +232,7 @@ pub(crate) fn bind_text64(
 }
 
 /// Wrapper around [`sqlite3_bind_int`].
+#[allow(dead_code)]
 pub(crate) fn bind_int(
     stmt: *mut sqlite3_stmt,
     index: i32,
@@ -247,6 +248,7 @@ pub(crate) fn bind_int(
 }
 
 /// Wrapper around [`sqlite3_bind_int64`].
+#[allow(dead_code)]
 pub(crate) fn bind_int64(
     stmt: *mut sqlite3_stmt,
     index: i32,

--- a/crates/musq/src/sqlite/mod.rs
+++ b/crates/musq/src/sqlite/mod.rs
@@ -1,4 +1,4 @@
-pub use arguments::{ArgumentValue, Arguments};
+pub use arguments::Arguments;
 pub use connection::Connection;
 pub use error::SqliteError;
 pub use statement::Statement;

--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -1,12 +1,12 @@
-use std::ffi::c_void;
 use std::ffi::CStr;
+use std::ffi::c_void;
 
 use std::os::raw::c_char;
 use std::ptr::NonNull;
 use std::str::from_utf8_unchecked;
 
 use libsqlite3_sys::{
-    sqlite3, sqlite3_stmt, SQLITE_DONE, SQLITE_LOCKED_SHAREDCACHE, SQLITE_MISUSE, SQLITE_ROW,
+    SQLITE_DONE, SQLITE_LOCKED_SHAREDCACHE, SQLITE_MISUSE, SQLITE_ROW, sqlite3, sqlite3_stmt,
 };
 
 use crate::sqlite::{
@@ -124,6 +124,7 @@ impl StatementHandle {
         )
     }
 
+    #[allow(dead_code)]
     pub(crate) fn bind_int(&self, index: usize, v: i32) -> std::result::Result<(), SqliteError> {
         ffi::bind_int(self.0.as_ptr(), index as i32, v)
     }

--- a/crates/musq/src/types/bool.rs
+++ b/crates/musq/src/types/bool.rs
@@ -3,12 +3,12 @@ use crate::{
     decode::Decode,
     encode::Encode,
     error::DecodeError,
-    sqlite::{ArgumentValue, SqliteDataType, Value},
+    sqlite::{SqliteDataType, Value},
 };
 
 impl Encode for bool {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Int(self.into())
+    fn encode(self) -> Value {
+        Value::Integer(self.into(), None)
     }
 }
 

--- a/crates/musq/src/types/bstr.rs
+++ b/crates/musq/src/types/bstr.rs
@@ -1,7 +1,6 @@
 /// Conversions between `bstr` types and SQL types.
 use crate::{
-    ArgumentValue, SqliteDataType, Value, compatible, decode::Decode, encode::Encode,
-    error::DecodeError,
+    SqliteDataType, Value, compatible, decode::Decode, encode::Encode, error::DecodeError,
 };
 
 #[doc(no_inline)]
@@ -15,13 +14,13 @@ impl<'r> Decode<'r> for BString {
 }
 
 impl Encode for &BStr {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob(self.as_bytes().to_owned())
+    fn encode(self) -> Value {
+        Value::Blob(self.as_bytes().to_owned(), None)
     }
 }
 
 impl Encode for BString {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob(self.as_bytes().to_vec())
+    fn encode(self) -> Value {
+        Value::Blob(self.as_bytes().to_vec(), None)
     }
 }

--- a/crates/musq/src/types/bytes.rs
+++ b/crates/musq/src/types/bytes.rs
@@ -1,13 +1,12 @@
 use std::sync::Arc;
 
 use crate::{
-    ArgumentValue, SqliteDataType, Value, compatible, decode::Decode, encode::Encode,
-    error::DecodeError,
+    SqliteDataType, Value, compatible, decode::Decode, encode::Encode, error::DecodeError,
 };
 
 impl Encode for &[u8] {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob(self.to_owned())
+    fn encode(self) -> Value {
+        Value::Blob(self.to_owned(), None)
     }
 }
 
@@ -19,8 +18,8 @@ impl<'r> Decode<'r> for &'r [u8] {
 }
 
 impl Encode for Vec<u8> {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob(self)
+    fn encode(self) -> Value {
+        Value::Blob(self, None)
     }
 }
 
@@ -32,8 +31,8 @@ impl<'r> Decode<'r> for Vec<u8> {
 }
 
 impl Encode for Arc<Vec<u8>> {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Blob((*self).clone())
+    fn encode(self) -> Value {
+        Value::Blob((*self).clone(), None)
     }
 }
 

--- a/crates/musq/src/types/float.rs
+++ b/crates/musq/src/types/float.rs
@@ -3,12 +3,12 @@ use crate::{
     decode::Decode,
     encode::Encode,
     error::DecodeError,
-    sqlite::{ArgumentValue, SqliteDataType, Value},
+    sqlite::{SqliteDataType, Value},
 };
 
 impl Encode for f32 {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Double(self.into())
+    fn encode(self) -> Value {
+        Value::Double(self.into(), None)
     }
 }
 
@@ -20,8 +20,8 @@ impl<'r> Decode<'r> for f32 {
 }
 
 impl Encode for f64 {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Double(self)
+    fn encode(self) -> Value {
+        Value::Double(self, None)
     }
 }
 

--- a/crates/musq/src/types/int.rs
+++ b/crates/musq/src/types/int.rs
@@ -3,12 +3,12 @@ use crate::{
     decode::Decode,
     encode::Encode,
     error::DecodeError,
-    sqlite::{ArgumentValue, SqliteDataType, Value},
+    sqlite::{SqliteDataType, Value},
 };
 
 impl Encode for i8 {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Int(self as i32)
+    fn encode(self) -> Value {
+        Value::Integer(self as i64, None)
     }
 }
 
@@ -21,8 +21,8 @@ impl<'r> Decode<'r> for i8 {
 }
 
 impl Encode for i16 {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Int(self as i32)
+    fn encode(self) -> Value {
+        Value::Integer(self as i64, None)
     }
 }
 
@@ -35,8 +35,8 @@ impl<'r> Decode<'r> for i16 {
 }
 
 impl Encode for i32 {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Int(self)
+    fn encode(self) -> Value {
+        Value::Integer(self as i64, None)
     }
 }
 
@@ -48,8 +48,8 @@ impl<'r> Decode<'r> for i32 {
 }
 
 impl Encode for i64 {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Int64(self)
+    fn encode(self) -> Value {
+        Value::Integer(self, None)
     }
 }
 

--- a/crates/musq/src/types/str.rs
+++ b/crates/musq/src/types/str.rs
@@ -1,13 +1,12 @@
 use std::sync::Arc;
 
 use crate::{
-    ArgumentValue, SqliteDataType, Value, compatible, decode::Decode, encode::Encode,
-    error::DecodeError,
+    SqliteDataType, Value, compatible, decode::Decode, encode::Encode, error::DecodeError,
 };
 
 impl Encode for &str {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Text(self.to_owned())
+    fn encode(self) -> Value {
+        Value::Text(self.as_bytes().to_vec(), None)
     }
 }
 
@@ -19,8 +18,8 @@ impl<'r> Decode<'r> for &'r str {
 }
 
 impl Encode for String {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Text(self)
+    fn encode(self) -> Value {
+        Value::Text(self.into_bytes(), None)
     }
 }
 
@@ -32,8 +31,8 @@ impl<'r> Decode<'r> for String {
 }
 
 impl Encode for Arc<String> {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Text((*self).clone())
+    fn encode(self) -> Value {
+        Value::Text((*self).clone().into_bytes(), None)
     }
 }
 

--- a/crates/musq/src/types/time.rs
+++ b/crates/musq/src/types/time.rs
@@ -1,38 +1,41 @@
 use crate::{
-    Value, compatible,
+    compatible,
     decode::Decode,
     encode::Encode,
     error::DecodeError,
-    sqlite::{ArgumentValue, SqliteDataType},
+    sqlite::{SqliteDataType, Value},
 };
 use time::format_description::{FormatItem, well_known::Rfc3339};
 use time::macros::format_description as fd;
 pub use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
 impl Encode for OffsetDateTime {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Text(self.format(&Rfc3339).unwrap())
+    fn encode(self) -> Value {
+        Value::Text(self.format(&Rfc3339).unwrap().into_bytes(), None)
     }
 }
 
 impl Encode for PrimitiveDateTime {
-    fn encode(self) -> ArgumentValue {
-        let format = fd!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond]");
-        ArgumentValue::Text(self.format(&format).unwrap())
+    fn encode(self) -> Value {
+        let format = fd!(
+            "[year]-[month]-[day] [hour padding:zero]:[minute padding:zero]:[second padding:zero].[subsecond]"
+        );
+        Value::Text(self.format(&format).unwrap().into_bytes(), None)
     }
 }
 
 impl Encode for Date {
-    fn encode(self) -> ArgumentValue {
+    fn encode(self) -> Value {
         let format = fd!("[year]-[month]-[day]");
-        ArgumentValue::Text(self.format(&format).unwrap())
+        Value::Text(self.format(&format).unwrap().into_bytes(), None)
     }
 }
 
 impl Encode for Time {
-    fn encode(self) -> ArgumentValue {
-        let format = fd!("[hour]:[minute]:[second].[subsecond]");
-        ArgumentValue::Text(self.format(&format).unwrap())
+    fn encode(self) -> Value {
+        let format =
+            fd!("[hour padding:zero]:[minute padding:zero]:[second padding:zero].[subsecond]");
+        Value::Text(self.format(&format).unwrap().into_bytes(), None)
     }
 }
 

--- a/crates/musq/src/types/uint.rs
+++ b/crates/musq/src/types/uint.rs
@@ -3,12 +3,12 @@ use crate::{
     decode::Decode,
     encode::Encode,
     error::DecodeError,
-    sqlite::{ArgumentValue, SqliteDataType, Value},
+    sqlite::{SqliteDataType, Value},
 };
 
 impl Encode for u8 {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Int(self as i32)
+    fn encode(self) -> Value {
+        Value::Integer(self as i64, None)
     }
 }
 
@@ -21,8 +21,8 @@ impl<'r> Decode<'r> for u8 {
 }
 
 impl Encode for u16 {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Int(self as i32)
+    fn encode(self) -> Value {
+        Value::Integer(self as i64, None)
     }
 }
 
@@ -35,8 +35,8 @@ impl<'r> Decode<'r> for u16 {
 }
 
 impl Encode for u32 {
-    fn encode(self) -> ArgumentValue {
-        ArgumentValue::Int64(self as i64)
+    fn encode(self) -> Value {
+        Value::Integer(self as i64, None)
     }
 }
 

--- a/examples/custom_type.rs
+++ b/examples/custom_type.rs
@@ -8,9 +8,9 @@ struct Foo {
 }
 
 impl encode::Encode for Foo {
-    fn encode(self) -> ArgumentValue {
+    fn encode(self) -> Value {
         let v = serde_json::to_string(&self).expect("failed to encode");
-        ArgumentValue::Text(std::sync::Arc::new(v))
+        Value::Text(v.into_bytes(), None)
     }
 }
 impl<'r> decode::Decode<'r> for Foo {


### PR DESCRIPTION
## Summary
- merge `ArgumentValue` and row `ValueData` into a single enum
- store `Value` directly inside `Arguments`
- adjust binding and type logic for `Row` and arguments
- update macros, types and examples to the new API

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c6bdd1a44833383d8a374938c45c1