### PR TITLE
Fix detach docs

### DIFF
--- a/crates/musq/src/pool/connection.rs
+++ b/crates/musq/src/pool/connection.rs
@@ -82,8 +82,6 @@ impl PoolConnection {
     /// Note that if your application uses a single shared pool, this
     /// effectively lets the application exceed the `max_connections` setting.
     ///
-    /// If `min_connections` is nonzero, a task will be spawned to replace this connection.
-    ///
     /// If you want the pool to treat this connection as permanently checked-out,
     /// use [`.leak()`][Self::leak] instead.
     ///


### PR DESCRIPTION
## Summary
- update `PoolConnection::detach` docs to remove outdated note about `min_connections`

## Testing
- `cargo fmt --all` *(fails: command not found)*
- `cargo clippy --workspace --tests` *(fails: command not found)*
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c742c3210833381f1c62bbe60251b