### PR TITLE
Remove unused trait check

### DIFF
--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -276,15 +276,3 @@ impl fmt::Debug for Pool {
             .finish()
     }
 }
-
-#[test]
-#[allow(dead_code)]
-fn assert_pool_traits() {
-    fn assert_send_sync<T: Send + Sync>() {}
-    fn assert_clone<T: Clone>() {}
-
-    fn assert_pool() {
-        assert_send_sync::<Pool>();
-        assert_clone::<Pool>();
-    }
-}


### PR DESCRIPTION
## Summary
- delete the compile-time trait assertion `assert_pool_traits`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c74bff6d4833398df8cd1de153d69