### PR TITLE
Document SQLite FFI preconditions

### DIFF
--- a/crates/musq/src/sqlite/ffi.rs
+++ b/crates/musq/src/sqlite/ffi.rs
@@ -18,6 +18,15 @@ const fn assert_c_int_is_32bit() {
 const _ASSERT_C_INT_32BIT: () = assert_c_int_is_32bit();
 
 /// Wrapper around [`sqlite3_open_v2`].
+///
+/// # Safety
+/// - `filename` must point to a valid NUL terminated string.
+/// - `handle` must be a valid pointer to receive the database handle and must
+///   not be accessed concurrently.
+/// - `vfs` may be null or must point to a valid NUL terminated string.
+///
+/// See <https://www.sqlite.org/c3ref/open.html>
+#[inline]
 pub(crate) fn open_v2(
     filename: *const c_char,
     handle: *mut *mut sqlite3,
@@ -53,6 +62,12 @@ pub(crate) fn open_v2(
 }
 
 /// Wrapper around [`sqlite3_extended_result_codes`].
+///
+/// # Safety
+/// - `db` must be a valid pointer to an open SQLite connection.
+///
+/// See <https://www.sqlite.org/c3ref/errcode.html#sqlite3extendedresultcodes>
+#[inline]
 pub(crate) fn extended_result_codes(
     db: *mut sqlite3,
     onoff: i32,
@@ -66,6 +81,12 @@ pub(crate) fn extended_result_codes(
 }
 
 /// Wrapper around [`sqlite3_busy_timeout`].
+///
+/// # Safety
+/// - `db` must be a valid pointer to an open SQLite connection.
+///
+/// See <https://www.sqlite.org/c3ref/busy_timeout.html>
+#[inline]
 pub(crate) fn busy_timeout(db: *mut sqlite3, ms: i32) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_busy_timeout(db, ms as c_int) };
     if rc == ffi_sys::SQLITE_OK {
@@ -76,6 +97,14 @@ pub(crate) fn busy_timeout(db: *mut sqlite3, ms: i32) -> std::result::Result<(),
 }
 
 /// Wrapper around [`sqlite3_prepare_v3`].
+///
+/// # Safety
+/// - `db` must be a valid SQLite database handle.
+/// - `sql` must point to a valid SQL statement with at least `n_byte` bytes.
+/// - `stmt` and `tail` must be valid pointers to receive output.
+///
+/// See <https://www.sqlite.org/c3ref/prepare.html>
+#[inline]
 pub(crate) fn prepare_v3(
     db: *mut sqlite3,
     sql: *const c_char,
@@ -93,6 +122,13 @@ pub(crate) fn prepare_v3(
 }
 
 /// Wrapper around [`sqlite3_progress_handler`].
+///
+/// # Safety
+/// - `db` must be a valid SQLite handle.
+/// - `callback` must remain valid for the lifetime of the registration.
+///
+/// See <https://www.sqlite.org/c3ref/progress_handler.html>
+#[inline]
 pub(crate) fn progress_handler(
     db: *mut sqlite3,
     num_ops: i32,
@@ -105,6 +141,13 @@ pub(crate) fn progress_handler(
 }
 
 /// Wrapper around [`sqlite3_unlock_notify`].
+///
+/// # Safety
+/// - `db` must be a valid SQLite handle.
+/// - `callback` must remain valid until invocation.
+///
+/// See <https://www.sqlite.org/c3ref/unlock_notify.html>
+#[inline]
 pub(crate) fn unlock_notify(
     db: *mut sqlite3,
     callback: Option<unsafe extern "C" fn(*mut *mut c_void, c_int)>,
@@ -119,16 +162,34 @@ pub(crate) fn unlock_notify(
 }
 
 /// Wrapper around [`sqlite3_extended_errcode`].
+///
+/// # Safety
+/// - `db` must be a valid SQLite connection handle.
+///
+/// See <https://www.sqlite.org/c3ref/errcode.html#sqlite3extendederrcode>
+#[inline]
 pub(crate) fn extended_errcode(db: *mut sqlite3) -> i32 {
     unsafe { ffi_sys::sqlite3_extended_errcode(db) as i32 }
 }
 
 /// Wrapper around [`sqlite3_errmsg`].
+///
+/// # Safety
+/// - `db` must be a valid SQLite connection handle.
+///
+/// See <https://www.sqlite.org/c3ref/errcode.html#sqlite3errmsg>
+#[inline]
 pub(crate) fn errmsg(db: *mut sqlite3) -> *const c_char {
     unsafe { ffi_sys::sqlite3_errmsg(db) }
 }
 
 /// Wrapper around [`sqlite3_close`].
+///
+/// # Safety
+/// - `db` must be a valid SQLite connection handle.
+///
+/// See <https://www.sqlite.org/c3ref/close.html>
+#[inline]
 pub(crate) fn close(db: *mut sqlite3) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_close(db) };
     if rc == ffi_sys::SQLITE_OK {
@@ -139,6 +200,13 @@ pub(crate) fn close(db: *mut sqlite3) -> std::result::Result<(), SqliteError> {
 }
 
 /// Wrapper around [`sqlite3_exec`] with no callback.
+///
+/// # Safety
+/// - `db` must be a valid SQLite connection.
+/// - `sql` must point to a valid NUL terminated SQL statement.
+///
+/// See <https://www.sqlite.org/c3ref/exec.html>
+#[inline]
 pub(crate) fn exec(db: *mut sqlite3, sql: *const c_char) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_exec(db, sql, None, ptr::null_mut(), ptr::null_mut()) };
     if rc == ffi_sys::SQLITE_OK {
@@ -149,46 +217,101 @@ pub(crate) fn exec(db: *mut sqlite3, sql: *const c_char) -> std::result::Result<
 }
 
 /// Wrapper around [`sqlite3_last_insert_rowid`].
+///
+/// # Safety
+/// - `db` must be a valid SQLite connection handle.
+///
+/// See <https://www.sqlite.org/c3ref/last_insert_rowid.html>
+#[inline]
 pub(crate) fn last_insert_rowid(db: *mut sqlite3) -> i64 {
     unsafe { ffi_sys::sqlite3_last_insert_rowid(db) }
 }
 
 /// Wrapper around [`sqlite3_db_handle`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/db_handle.html>
+#[inline]
 pub(crate) fn db_handle(stmt: *mut sqlite3_stmt) -> *mut sqlite3 {
     unsafe { ffi_sys::sqlite3_db_handle(stmt) }
 }
 
 /// Wrapper around [`sqlite3_column_count`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/column_count.html>
+#[inline]
 pub(crate) fn column_count(stmt: *mut sqlite3_stmt) -> i32 {
     unsafe { ffi_sys::sqlite3_column_count(stmt) as i32 }
 }
 
 /// Wrapper around [`sqlite3_changes`].
+///
+/// # Safety
+/// - `db` must be a valid SQLite connection handle.
+///
+/// See <https://www.sqlite.org/c3ref/changes.html>
+#[inline]
 pub(crate) fn changes(db: *mut sqlite3) -> i32 {
     unsafe { ffi_sys::sqlite3_changes(db) as i32 }
 }
 
-/// Wrapper around [`sqlite3_column_name`]. Returns a pointer to a null terminated string.
+/// Wrapper around [`sqlite3_column_name`]. Returns a pointer to a NUL terminated string.
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/column_name.html>
+#[inline]
 pub(crate) fn column_name(stmt: *mut sqlite3_stmt, index: i32) -> *const c_char {
     unsafe { ffi_sys::sqlite3_column_name(stmt, index as c_int) }
 }
 
 /// Wrapper around [`sqlite3_column_decltype`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/column_decltype.html>
+#[inline]
 pub(crate) fn column_decltype(stmt: *mut sqlite3_stmt, index: i32) -> *const c_char {
     unsafe { ffi_sys::sqlite3_column_decltype(stmt, index as c_int) }
 }
 
 /// Wrapper around [`sqlite3_bind_parameter_count`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/bind_parameter_count.html>
+#[inline]
 pub(crate) fn bind_parameter_count(stmt: *mut sqlite3_stmt) -> i32 {
     unsafe { ffi_sys::sqlite3_bind_parameter_count(stmt) as i32 }
 }
 
 /// Wrapper around [`sqlite3_bind_parameter_name`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/bind_parameter_name.html>
+#[inline]
 pub(crate) fn bind_parameter_name(stmt: *mut sqlite3_stmt, index: i32) -> *const c_char {
     unsafe { ffi_sys::sqlite3_bind_parameter_name(stmt, index as c_int) }
 }
 
 /// Wrapper around [`sqlite3_bind_blob64`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+/// - `data` must point to `len` valid bytes.
+///
+/// See <https://www.sqlite.org/c3ref/bind_blob.html>
+#[inline]
 pub(crate) fn bind_blob64(
     stmt: *mut sqlite3_stmt,
     index: i32,
@@ -207,6 +330,13 @@ pub(crate) fn bind_blob64(
 }
 
 /// Wrapper around [`sqlite3_bind_text64`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+/// - `data` must point to `len` bytes representing UTF-8 text.
+///
+/// See <https://www.sqlite.org/c3ref/bind_blob.html>
+#[inline]
 pub(crate) fn bind_text64(
     stmt: *mut sqlite3_stmt,
     index: i32,
@@ -232,6 +362,12 @@ pub(crate) fn bind_text64(
 }
 
 /// Wrapper around [`sqlite3_bind_int`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/bind_blob.html>
+#[inline]
 pub(crate) fn bind_int(
     stmt: *mut sqlite3_stmt,
     index: i32,
@@ -247,6 +383,12 @@ pub(crate) fn bind_int(
 }
 
 /// Wrapper around [`sqlite3_bind_int64`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/bind_blob.html>
+#[inline]
 pub(crate) fn bind_int64(
     stmt: *mut sqlite3_stmt,
     index: i32,
@@ -262,6 +404,12 @@ pub(crate) fn bind_int64(
 }
 
 /// Wrapper around [`sqlite3_bind_double`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/bind_blob.html>
+#[inline]
 pub(crate) fn bind_double(
     stmt: *mut sqlite3_stmt,
     index: i32,
@@ -277,6 +425,12 @@ pub(crate) fn bind_double(
 }
 
 /// Wrapper around [`sqlite3_bind_null`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/bind_blob.html>
+#[inline]
 pub(crate) fn bind_null(
     stmt: *mut sqlite3_stmt,
     index: i32,
@@ -291,36 +445,78 @@ pub(crate) fn bind_null(
 }
 
 /// Wrapper around [`sqlite3_column_type`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/column_blob.html>
+#[inline]
 pub(crate) fn column_type(stmt: *mut sqlite3_stmt, index: i32) -> i32 {
     unsafe { ffi_sys::sqlite3_column_type(stmt, index as c_int) as i32 }
 }
 
 /// Wrapper around [`sqlite3_column_int64`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/column_blob.html>
+#[inline]
 pub(crate) fn column_int64(stmt: *mut sqlite3_stmt, index: i32) -> i64 {
     unsafe { ffi_sys::sqlite3_column_int64(stmt, index as c_int) }
 }
 
 /// Wrapper around [`sqlite3_column_double`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/column_blob.html>
+#[inline]
 pub(crate) fn column_double(stmt: *mut sqlite3_stmt, index: i32) -> f64 {
     unsafe { ffi_sys::sqlite3_column_double(stmt, index as c_int) }
 }
 
 /// Wrapper around [`sqlite3_column_blob`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/column_blob.html>
+#[inline]
 pub(crate) fn column_blob(stmt: *mut sqlite3_stmt, index: i32) -> *const c_void {
     unsafe { ffi_sys::sqlite3_column_blob(stmt, index as c_int) }
 }
 
 /// Wrapper around [`sqlite3_column_bytes`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/column_blob.html>
+#[inline]
 pub(crate) fn column_bytes(stmt: *mut sqlite3_stmt, index: i32) -> i32 {
     unsafe { ffi_sys::sqlite3_column_bytes(stmt, index as c_int) as i32 }
 }
 
 /// Wrapper around [`sqlite3_clear_bindings`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/clear_bindings.html>
+#[inline]
 pub(crate) fn clear_bindings(stmt: *mut sqlite3_stmt) {
     unsafe { ffi_sys::sqlite3_clear_bindings(stmt) };
 }
 
 /// Wrapper around [`sqlite3_reset`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/reset.html>
+#[inline]
 pub(crate) fn reset(stmt: *mut sqlite3_stmt) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_reset(stmt) };
     if rc == ffi_sys::SQLITE_OK {
@@ -332,6 +528,12 @@ pub(crate) fn reset(stmt: *mut sqlite3_stmt) -> std::result::Result<(), SqliteEr
 }
 
 /// Wrapper around [`sqlite3_step`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/step.html>
+#[inline]
 pub(crate) fn step(stmt: *mut sqlite3_stmt) -> std::result::Result<i32, SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_step(stmt) };
     if rc == ffi_sys::SQLITE_ROW
@@ -350,6 +552,12 @@ pub(crate) fn step(stmt: *mut sqlite3_stmt) -> std::result::Result<i32, SqliteEr
 }
 
 /// Wrapper around [`sqlite3_finalize`].
+///
+/// # Safety
+/// - `stmt` must be a valid prepared statement pointer.
+///
+/// See <https://www.sqlite.org/c3ref/finalize.html>
+#[inline]
 pub(crate) fn finalize(stmt: *mut sqlite3_stmt) -> std::result::Result<(), SqliteError> {
     let rc = unsafe { ffi_sys::sqlite3_finalize(stmt) };
     if rc == ffi_sys::SQLITE_OK {


### PR DESCRIPTION
## Summary
- document safety preconditions for all FFI wrappers in `sqlite/ffi.rs`
- add links to the SQLite C API documentation
- inline small wrappers for reduced overhead

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`


------
https://chatgpt.com/codex/tasks/task_e_687c76c20c34833390df43ce8dd84296