### PR TITLE
Ensure connection worker is shut down on drop

### DIFF
--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -7,6 +7,7 @@ use std::{
 
 use crate::sqlite::ffi;
 use futures_core::{future::BoxFuture, stream::BoxStream};
+use futures_executor::block_on;
 use futures_util::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, future};
 use libsqlite3_sys::sqlite3;
 use tokio::sync::MutexGuard;
@@ -138,12 +139,7 @@ impl Connection {
             pragma_string.push_str("PRAGMA optimize;");
             self.execute(crate::query(&pragma_string)).await?;
         }
-        // Destructure self to extract the worker and avoid partial move
-        let Connection { mut worker, .. } = self;
-        let shutdown = worker.shutdown();
-        // The rest of self is dropped here
-        // Ensure the worker thread has terminated
-        shutdown.await
+        self.worker.shutdown().await
     }
 
     /// Immediately close the connection without sending a graceful shutdown.
@@ -419,6 +415,15 @@ impl LockedSqliteHandle<'_> {
     /// Removes the progress handler on a database connection. The method does nothing if no handler was set.
     pub fn remove_progress_handler(&mut self) {
         self.guard.remove_progress_handler();
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // best effort shutdown of the worker thread
+        if !self.worker.is_shutdown() {
+            let _ = block_on(self.worker.shutdown());
+        }
     }
 }
 

--- a/crates/musq/src/sqlite/connection/worker.rs
+++ b/crates/musq/src/sqlite/connection/worker.rs
@@ -247,6 +247,10 @@ impl ConnectionWorker {
         })
     }
 
+    pub(crate) fn is_shutdown(&self) -> bool {
+        self.join_handle.is_none()
+    }
+
     pub(crate) async fn prepare(&mut self, query: &str) -> Result<Statement> {
         self.oneshot_cmd(|tx| Command::Prepare {
             query: query.into(),

--- a/crates/musq/tests/sqlite.rs
+++ b/crates/musq/tests/sqlite.rs
@@ -903,3 +903,17 @@ async fn it_fails_on_missing_bind() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn connection_drops_without_close() -> anyhow::Result<()> {
+    use musq_test::connection;
+
+    let conn = connection().await?;
+    drop(conn);
+
+    // ensure a new connection can be established after dropping
+    let conn2 = connection().await?;
+    conn2.close().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement `Drop` for `Connection` to synchronously shutdown the worker
- expose `ConnectionWorker::is_shutdown` for checking shutdown state
- add regression test covering dropping a connection without calling `.close()`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c7722b0048333a01cf53096f2a483