### PR TITLE
Add retry helper for SQLite error handling

### DIFF
--- a/crates/musq/src/sqlite/connection/handle.rs
+++ b/crates/musq/src/sqlite/connection/handle.rs
@@ -6,7 +6,7 @@ use crate::sqlite::ffi;
 
 use crate::{
     Error, Result,
-    sqlite::{DEFAULT_MAX_RETRIES, error::ExtendedErrCode, statement::unlock_notify},
+    sqlite::{DEFAULT_MAX_RETRIES, statement::unlock_notify},
 };
 
 /// Managed handle to the raw SQLite3 database handle.
@@ -53,7 +53,7 @@ impl ConnectionHandle {
         loop {
             match ffi::exec(self.as_ptr(), query.as_ptr()) {
                 Ok(()) => return Ok(()),
-                Err(e) if e.extended == ExtendedErrCode::LockedSharedCache => {
+                Err(e) if e.should_retry() => {
                     if attempts >= DEFAULT_MAX_RETRIES {
                         return Err(Error::UnlockNotify);
                     }

--- a/crates/musq/src/sqlite/error.rs
+++ b/crates/musq/src/sqlite/error.rs
@@ -243,6 +243,15 @@ impl ExtendedErrCode {
             _ => ExtendedErrCode::Unknown(code as u32),
         }
     }
+
+    pub fn is_busy(&self) -> bool {
+        matches!(
+            self,
+            ExtendedErrCode::BusyRecovery
+                | ExtendedErrCode::BusySnapshot
+                | ExtendedErrCode::BusyTimeout
+        )
+    }
 }
 
 /// An error returned from Sqlite
@@ -269,5 +278,15 @@ impl SqliteError {
             primary: PrimaryErrCode::from_code(code),
             message,
         }
+    }
+
+    pub fn is_busy(&self) -> bool {
+        self.primary == PrimaryErrCode::Busy || self.extended.is_busy()
+    }
+
+    pub fn should_retry(&self) -> bool {
+        self.primary == PrimaryErrCode::Locked
+            || self.extended == ExtendedErrCode::LockedSharedCache
+            || self.is_busy()
     }
 }


### PR DESCRIPTION
## Summary
- add `SqliteError::should_retry()` to detect locked and busy states
- consolidate retry checks in connection exec
- simplify compound statement prepare retry logic
- update statement step loops to use the new helper

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c7be561d88333b1b28c0d84e8ef13