### PR TITLE
Reset all statement handles

### DIFF
--- a/crates/musq/src/sqlite/statement/compound.rs
+++ b/crates/musq/src/sqlite/statement/compound.rs
@@ -136,12 +136,21 @@ impl CompoundStatement {
     pub fn reset(&mut self) -> Result<()> {
         self.index = None;
 
+        let mut first_err: Option<Error> = None;
+
         for handle in self.handles.iter_mut() {
-            handle.reset()?;
+            if let Err(e) = handle.reset() {
+                if first_err.is_none() {
+                    first_err = Some(e.into());
+                }
+            }
             handle.clear_bindings();
         }
 
-        Ok(())
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure `CompoundStatement::reset` continues resetting all handles even if an earlier reset fails

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c826fa4248333b39194a3e5e5ff60