### PR TITLE
Make constants crate-private

### DIFF
--- a/crates/musq/src/sqlite/mod.rs
+++ b/crates/musq/src/sqlite/mod.rs
@@ -19,4 +19,4 @@ pub(crate) mod value;
 /// [`ConnectionHandle::exec`] and [`StatementHandle::step`] use this constant to
 /// limit how many unlock notification attempts will be made before returning
 /// [`Error::UnlockNotify`].
-pub const DEFAULT_MAX_RETRIES: usize = 5;
+pub(crate) const DEFAULT_MAX_RETRIES: usize = 5;

--- a/crates/musq/src/statement_cache.rs
+++ b/crates/musq/src/statement_cache.rs
@@ -2,7 +2,7 @@ use crate::{Result, sqlite::statement::CompoundStatement};
 use hashlink::lru_cache::LruCache;
 
 /// Default capacity for [`StatementCache`].
-pub const DEFAULT_CAPACITY: usize = 1024;
+pub(crate) const DEFAULT_CAPACITY: usize = 1024;
 
 /// A cache for prepared statements. When full, the least recently used
 /// statement gets removed.


### PR DESCRIPTION
## Summary
- make DEFAULT_MAX_RETRIES crate-private
- make DEFAULT_CAPACITY crate-private

## Testing
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c859b1ab0833380e1f2e6b2e05254