### PR TITLE
Restrict OptimizeOnClose visibility

### DIFF
--- a/crates/musq/src/musq.rs
+++ b/crates/musq/src/musq.rs
@@ -92,7 +92,7 @@ pub struct Musq {
 }
 
 #[derive(Clone, Debug)]
-pub enum OptimizeOnClose {
+pub(crate) enum OptimizeOnClose {
     Enabled { analysis_limit: Option<u32> },
     Disabled,
 }


### PR DESCRIPTION
## Summary
- make `OptimizeOnClose` internal to the crate

## Testing
- `cargo fmt --all`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c89dab39c8333b7845f882eb72cf0