### PR TITLE
Remove hidden docs for Pool struct

### DIFF
--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -22,7 +22,6 @@ mod connection;
 mod inner;
 
 pub use self::connection::PoolConnection;
-#[doc(hidden)]
 /// An asynchronous pool of database connections.
 ///
 /// Create a pool with [`Musq::open`] or [`Musq::open_in_memory`] and then call [`Pool::acquire`] to get a connection


### PR DESCRIPTION
## Summary
- remove `#[doc(hidden)]` attribute on `Pool`
- verify generated documentation for `Pool`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo doc --workspace`


------
https://chatgpt.com/codex/tasks/task_e_687c89e655cc8333a32efee0d83b6994