### PR TITLE
Remove QueryResult Extend

### DIFF
--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -236,7 +236,13 @@ impl Pool {
     where
         E: Execute + 'q,
     {
-        self.execute_many(query).try_collect().boxed()
+        self.execute_many(query)
+            .try_fold(QueryResult::default(), |mut acc, qr| async move {
+                acc.changes += qr.changes;
+                acc.last_insert_rowid = qr.last_insert_rowid;
+                Ok(acc)
+            })
+            .boxed()
     }
 
     pub fn fetch_all<'c, 'q: 'c, E>(&'c self, query: E) -> BoxFuture<'c, Result<Vec<Row>>>

--- a/crates/musq/src/query_result.rs
+++ b/crates/musq/src/query_result.rs
@@ -1,5 +1,3 @@
-use std::iter::{Extend, IntoIterator};
-
 #[derive(Debug, Default)]
 pub struct QueryResult {
     pub(super) changes: u64,
@@ -13,14 +11,5 @@ impl QueryResult {
 
     pub fn last_insert_rowid(&self) -> i64 {
         self.last_insert_rowid
-    }
-}
-
-impl Extend<QueryResult> for QueryResult {
-    fn extend<T: IntoIterator<Item = QueryResult>>(&mut self, iter: T) {
-        for elem in iter {
-            self.changes += elem.changes;
-            self.last_insert_rowid = elem.last_insert_rowid;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- drop the `Extend<QueryResult>` impl
- aggregate query results using `try_fold`

## Testing
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c8a0da87083339e146e6c4b53aaae