### PR TITLE
Limit Musq::in_memory visibility

### DIFF
--- a/crates/musq/src/musq.rs
+++ b/crates/musq/src/musq.rs
@@ -169,9 +169,11 @@ impl Musq {
         }
     }
 
-    /// Set the filename as in-memory. Use the `open_in_memory` method instead, unless you have a very particular use
-    /// case.
-    pub fn in_memory(mut self, val: bool) -> Self {
+    /// Set the filename as in-memory.
+    ///
+    /// This is intended for internal use. External callers should use
+    /// [`open_in_memory`](Self::open_in_memory) to create an in-memory database.
+    pub(crate) fn in_memory(mut self, val: bool) -> Self {
         self.in_memory = val;
         self
     }


### PR DESCRIPTION
## Summary
- narrow visibility of `Musq::in_memory` to `pub(crate)`
- mention `open_in_memory` in docs

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_687c8a6fcd608333960d2533037f29fc