### PR TITLE
Remove AsRef/AsMut from PoolConnection

### DIFF
--- a/crates/musq/src/pool/connection.rs
+++ b/crates/musq/src/pool/connection.rs
@@ -52,18 +52,6 @@ impl DerefMut for PoolConnection {
     }
 }
 
-impl AsRef<Connection> for PoolConnection {
-    fn as_ref(&self) -> &Connection {
-        self
-    }
-}
-
-impl AsMut<Connection> for PoolConnection {
-    fn as_mut(&mut self) -> &mut Connection {
-        self
-    }
-}
-
 impl PoolConnection {
     /// Close this connection, allowing the pool to open a replacement.
     ///


### PR DESCRIPTION
## Summary
- delete `AsRef` and `AsMut` implementations from `PoolConnection`

## Testing
- `cargo clippy --all-targets --all-features -q`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687c931cad188333910607048b3ed229