### PR TITLE
Remove unused Column serialization

### DIFF
--- a/crates/musq/src/column.rs
+++ b/crates/musq/src/column.rs
@@ -2,7 +2,7 @@ use crate::{sqlite::SqliteDataType, ustr::UStr};
 
 use std::fmt::Debug;
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Column {
     pub(crate) name: UStr,
     pub(crate) ordinal: usize,

--- a/crates/musq/src/sqlite/arguments.rs
+++ b/crates/musq/src/sqlite/arguments.rs
@@ -64,10 +64,10 @@ impl Arguments {
 
     pub(super) fn bind(&self, handle: &mut StatementHandle, offset: usize) -> Result<usize> {
         let mut next_pos = offset;
-        if let Some(max) = self.named.values().max().cloned() {
-            if max > next_pos {
-                next_pos = max;
-            }
+        if let Some(max) = self.named.values().max().cloned()
+            && max > next_pos
+        {
+            next_pos = max;
         }
         // Track mappings from positional-parameter-introduced names to their
         // argument indices so that multiple references to the same name are

--- a/crates/musq/src/sqlite/connection/worker.rs
+++ b/crates/musq/src/sqlite/connection/worker.rs
@@ -207,14 +207,12 @@ impl ConnectionWorker {
 
                             let res_ok = res.is_ok();
 
-                            if let Some(tx) = tx {
-                                if tx.blocking_send(res).is_err() && res_ok {
-                                    // The ROLLBACK was processed but not acknowledged. This means
-                                    // that the `Transaction` doesn't know it was rolled back and
-                                    // will try to rollback again on drop. We need to ignore that
-                                    // rollback.
-                                    ignore_next_start_rollback = true;
-                                }
+                            if let Some(tx) = tx && tx.blocking_send(res).is_err() && res_ok {
+                                // The ROLLBACK was processed but not acknowledged. This means
+                                // that the `Transaction` doesn't know it was rolled back and
+                                // will try to rollback again on drop. We need to ignore that
+                                // rollback.
+                                ignore_next_start_rollback = true;
                             }
                         }
                         Command::ClearCache { tx } => {

--- a/crates/musq/src/sqlite/statement/compound.rs
+++ b/crates/musq/src/sqlite/statement/compound.rs
@@ -139,10 +139,10 @@ impl CompoundStatement {
         let mut first_err: Option<Error> = None;
 
         for handle in self.handles.iter_mut() {
-            if let Err(e) = handle.reset() {
-                if first_err.is_none() {
-                    first_err = Some(e.into());
-                }
+            if let Err(e) = handle.reset()
+                && first_err.is_none()
+            {
+                first_err = Some(e.into());
             }
             handle.clear_bindings();
         }


### PR DESCRIPTION
## Summary
- drop `Serialize`/`Deserialize` derives from `Column`
- clean up collapsible if statements flagged by clippy

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c92f696f48333ae22d55c61c0438d