### PR TITLE
Handle lock poisoning without panicking

### DIFF
--- a/crates/musq/src/error.rs
+++ b/crates/musq/src/error.rs
@@ -2,6 +2,9 @@
 
 use std::io;
 use std::num::TryFromIntError;
+use std::sync::PoisonError;
+
+use tokio::sync::TryLockError;
 
 use crate::{SqliteDataType, sqlite, sqlite::error::SqliteError};
 
@@ -112,5 +115,17 @@ impl Error {
 impl From<SqliteError> for Error {
     fn from(error: SqliteError) -> Self {
         Error::Sqlite(error)
+    }
+}
+
+impl<T> From<PoisonError<T>> for Error {
+    fn from(_: PoisonError<T>) -> Self {
+        Error::WorkerCrashed
+    }
+}
+
+impl From<TryLockError> for Error {
+    fn from(_: TryLockError) -> Self {
+        Error::WorkerCrashed
     }
 }

--- a/crates/musq/src/sqlite/connection/worker.rs
+++ b/crates/musq/src/sqlite/connection/worker.rs
@@ -89,7 +89,13 @@ impl ConnectionWorker {
                     // configuration here.
                     conn: Mutex::new(conn),
                 });
-                let mut conn = shared.conn.try_lock().unwrap();
+                let mut conn = match shared.conn.try_lock() {
+                    Ok(lock) => lock,
+                    Err(e) => {
+                        establish_tx.send(Err(e.into())).ok();
+                        return;
+                    }
+                };
 
                 if establish_tx
                     .send(Ok((command_tx, Arc::clone(&shared))))


### PR DESCRIPTION
## Summary
- avoid unwrapping poisoned locks in `unlock_notify::Notify`
- return errors when the startup mutex is poisoned
- convert `PoisonError` and `TryLockError` into `Error`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c9280e2448333a06705ab5c5bd925