### PR TITLE
Handle unknown column types

### DIFF
--- a/crates/musq/src/error.rs
+++ b/crates/musq/src/error.rs
@@ -63,6 +63,10 @@ pub enum Error {
     #[error("no column found for name: {0}")]
     ColumnNotFound(String),
 
+    /// Encountered an unknown column type code.
+    #[error("unknown column type: {0}")]
+    UnknownColumnType(i32),
+
     /// Error occurred while decoding a value from a specific column.
     #[error("error occurred while decoding column {index}: {source}")]
     ColumnDecode {

--- a/crates/musq/src/row.rs
+++ b/crates/musq/src/row.rs
@@ -30,7 +30,7 @@ impl Row {
         statement: &StatementHandle,
         columns: &Arc<Vec<Column>>,
         column_names: &Arc<HashMap<UStr, usize>>,
-    ) -> Self {
+    ) -> Result<Self> {
         use crate::sqlite::Value;
         use libsqlite3_sys::SQLITE_NULL;
 
@@ -98,17 +98,17 @@ impl Row {
                         },
                     }
                 }
-                _ => unreachable!(),
+                _ => return Err(Error::UnknownColumnType(code)),
             };
 
             values.push(val);
         }
 
-        Self {
+        Ok(Self {
             values: values.into_boxed_slice(),
             columns: Arc::clone(columns),
             column_names: Arc::clone(column_names),
-        }
+        })
     }
 
     /// Returns the values for this row.

--- a/crates/musq/src/sqlite/connection/execute.rs
+++ b/crates/musq/src/sqlite/connection/execute.rs
@@ -95,11 +95,10 @@ impl Iterator for ExecuteIter<'_> {
             Ok(true) => {
                 self.logger.inc_rows_returned();
 
-                Some(Ok(Either::Right(Row::current(
-                    statement.handle,
-                    statement.columns,
-                    statement.column_names,
-                ))))
+                match Row::current(statement.handle, statement.columns, statement.column_names) {
+                    Ok(row) => Some(Ok(Either::Right(row))),
+                    Err(e) => Some(Err(e)),
+                }
             }
             Ok(false) => {
                 let last_insert_rowid = self.handle.last_insert_rowid();


### PR DESCRIPTION
## Summary
- report unknown column types as an Error instead of panicking
- propagate this error when reading rows

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c922c998483339a489445ee72418c