### PR TITLE
Fix invalid UTF-8 handling

### DIFF
--- a/crates/musq/src/sqlite/error.rs
+++ b/crates/musq/src/sqlite/error.rs
@@ -1,5 +1,4 @@
 use std::ffi::CStr;
-use std::str::from_utf8_unchecked;
 
 use crate::sqlite::ffi;
 use libsqlite3_sys::{self, sqlite3};
@@ -269,9 +268,8 @@ impl SqliteError {
         let message = unsafe {
             let msg = ffi::errmsg(handle);
             debug_assert!(!msg.is_null());
-            from_utf8_unchecked(CStr::from_ptr(msg).to_bytes())
-        }
-        .to_owned();
+            CStr::from_ptr(msg).to_string_lossy().into_owned()
+        };
 
         Self {
             extended: ExtendedErrCode::from_code(code),

--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -3,7 +3,6 @@ use std::ffi::c_void;
 
 use std::os::raw::c_char;
 use std::ptr::NonNull;
-use std::str::from_utf8_unchecked;
 
 use libsqlite3_sys::{
     SQLITE_DONE, SQLITE_LOCKED_SHAREDCACHE, SQLITE_MISUSE, SQLITE_ROW, sqlite3, sqlite3_stmt,
@@ -77,7 +76,7 @@ impl StatementHandle {
             return None;
         }
 
-        let decl = unsafe { from_utf8_unchecked(CStr::from_ptr(decl).to_bytes()) };
+        let decl = unsafe { CStr::from_ptr(decl).to_string_lossy() };
         let ty: SqliteDataType = decl.parse().ok()?;
 
         Some(ty)

--- a/crates/musq/tests/invalid_utf8.rs
+++ b/crates/musq/tests/invalid_utf8.rs
@@ -1,0 +1,68 @@
+use libsqlite3_sys as ffi;
+use musq::query;
+use musq_test::connection;
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int};
+
+#[tokio::test]
+async fn invalid_utf8_error_message_does_not_panic() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+
+    {
+        let mut locked = conn.lock_handle().await?;
+        let db = locked.as_raw_handle().as_ptr();
+        unsafe extern "C" fn badfunc(
+            ctx: *mut ffi::sqlite3_context,
+            _argc: c_int,
+            _argv: *mut *mut ffi::sqlite3_value,
+        ) {
+            let msg: &[u8] = b"bad\xffmessage";
+            unsafe {
+                ffi::sqlite3_result_error(ctx, msg.as_ptr() as *const c_char, msg.len() as c_int);
+            }
+        }
+        let name = CString::new("badfunc").unwrap();
+        let rc = unsafe {
+            ffi::sqlite3_create_function_v2(
+                db,
+                name.as_ptr(),
+                0,
+                ffi::SQLITE_UTF8,
+                std::ptr::null_mut(),
+                Some(badfunc),
+                None,
+                None,
+                None,
+            )
+        };
+        assert_eq!(rc, ffi::SQLITE_OK);
+    }
+
+    let res = query("SELECT badfunc()").execute(&mut conn).await;
+    assert!(res.is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_utf8_column_decltype_does_not_panic() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    {
+        let mut locked = conn.lock_handle().await?;
+        let db = locked.as_raw_handle().as_ptr();
+        let sql = CString::new(b"CREATE TABLE t(col T\xff);".to_vec()).unwrap();
+        let rc = unsafe {
+            ffi::sqlite3_exec(
+                db,
+                sql.as_ptr(),
+                None,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, ffi::SQLITE_OK);
+    }
+
+    let rows = query("SELECT col FROM t").fetch_all(&mut conn).await?;
+    assert!(rows.is_empty());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- avoid `from_utf8_unchecked` when reading error strings
- handle invalid UTF-8 for column decltype
- add regression tests for invalid UTF-8

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c921cbc188333b488ca355e3baa3a