### PR TITLE
Restrict Row accessors

### DIFF
--- a/crates/musq/src/row.rs
+++ b/crates/musq/src/row.rs
@@ -111,16 +111,6 @@ impl Row {
         }
     }
 
-    /// Returns the values for this row.
-    pub fn values(&self) -> &[Value] {
-        self.values.as_ref()
-    }
-
-    /// Returns the column definitions for this row.
-    pub fn columns(&self) -> &[Column] {
-        self.columns.as_ref()
-    }
-
     /// Returns `true` if this row has no columns.
     pub fn is_empty(&self) -> bool {
         self.columns.len() == 0


### PR DESCRIPTION
## Summary
- narrow visibility for `Row` internals by removing unused accessors

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687c9308fa048333b869e33dabfb3910