### PR TITLE
Add numeric affinity support

### DIFF
--- a/crates/musq/src/sqlite/type_info.rs
+++ b/crates/musq/src/sqlite/type_info.rs
@@ -12,8 +12,7 @@ pub enum SqliteDataType {
     Text,
     Blob,
 
-    // TODO: Support NUMERIC
-    #[allow(dead_code)]
+    /// Values that follow SQLite's `NUMERIC` affinity.
     Numeric,
 
     // non-standard extensions
@@ -96,6 +95,8 @@ impl FromStr for SqliteDataType {
                 SqliteDataType::Float
             }
 
+            _ if s.contains("num") || s.contains("dec") => SqliteDataType::Numeric,
+
             _ => {
                 return Err(crate::Error::TypeNotFound {
                     type_name: original,
@@ -128,6 +129,9 @@ fn test_data_type_from_str() -> crate::Result<()> {
     assert_eq!(SqliteDataType::Float, "REAL".parse()?);
     assert_eq!(SqliteDataType::Float, "FLOAT".parse()?);
     assert_eq!(SqliteDataType::Float, "DOUBLE PRECISION".parse()?);
+
+    assert_eq!(SqliteDataType::Numeric, "NUMERIC".parse()?);
+    assert_eq!(SqliteDataType::Numeric, "DECIMAL(10,5)".parse()?);
 
     assert_eq!(SqliteDataType::Bool, "BOOLEAN".parse()?);
     assert_eq!(SqliteDataType::Bool, "BOOL".parse()?);

--- a/crates/musq/src/types/bool.rs
+++ b/crates/musq/src/types/bool.rs
@@ -18,7 +18,10 @@ impl<'r> Decode<'r> for bool {
     fn decode(value: &'r Value) -> std::result::Result<bool, DecodeError> {
         compatible!(
             value,
-            SqliteDataType::Bool | SqliteDataType::Int | SqliteDataType::Int64
+            SqliteDataType::Bool
+                | SqliteDataType::Int
+                | SqliteDataType::Int64
+                | SqliteDataType::Numeric
         );
         Ok(value.int()? != 0)
     }

--- a/crates/musq/src/types/float.rs
+++ b/crates/musq/src/types/float.rs
@@ -16,7 +16,7 @@ impl Encode for f32 {
 
 impl<'r> Decode<'r> for f32 {
     fn decode(value: &'r Value) -> std::result::Result<f32, DecodeError> {
-        compatible!(value, SqliteDataType::Float);
+        compatible!(value, SqliteDataType::Float | SqliteDataType::Numeric);
         Ok(value.double()? as f32)
     }
 }
@@ -32,7 +32,7 @@ impl Encode for f64 {
 
 impl<'r> Decode<'r> for f64 {
     fn decode(value: &'r Value) -> std::result::Result<f64, DecodeError> {
-        compatible!(value, SqliteDataType::Float);
+        compatible!(value, SqliteDataType::Float | SqliteDataType::Numeric);
         value.double()
     }
 }

--- a/crates/musq/src/types/int.rs
+++ b/crates/musq/src/types/int.rs
@@ -16,7 +16,10 @@ impl Encode for i8 {
 
 impl<'r> Decode<'r> for i8 {
     fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
-        compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
+        compatible!(
+            value,
+            SqliteDataType::Int | SqliteDataType::Int64 | SqliteDataType::Numeric
+        );
         let v: i32 = value.int()?;
         Ok(v.try_into()?)
     }
@@ -33,7 +36,10 @@ impl Encode for i16 {
 
 impl<'r> Decode<'r> for i16 {
     fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
-        compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
+        compatible!(
+            value,
+            SqliteDataType::Int | SqliteDataType::Int64 | SqliteDataType::Numeric
+        );
         let v: i32 = value.int()?;
         Ok(v.try_into()?)
     }
@@ -50,7 +56,10 @@ impl Encode for i32 {
 
 impl<'r> Decode<'r> for i32 {
     fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
-        compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
+        compatible!(
+            value,
+            SqliteDataType::Int | SqliteDataType::Int64 | SqliteDataType::Numeric
+        );
         value.int()
     }
 }
@@ -66,7 +75,10 @@ impl Encode for i64 {
 
 impl<'r> Decode<'r> for i64 {
     fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
-        compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
+        compatible!(
+            value,
+            SqliteDataType::Int | SqliteDataType::Int64 | SqliteDataType::Numeric
+        );
         value.int64()
     }
 }

--- a/crates/musq/src/types/uint.rs
+++ b/crates/musq/src/types/uint.rs
@@ -16,7 +16,10 @@ impl Encode for u8 {
 
 impl<'r> Decode<'r> for u8 {
     fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
-        compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
+        compatible!(
+            value,
+            SqliteDataType::Int | SqliteDataType::Int64 | SqliteDataType::Numeric
+        );
         let v: i32 = value.int()?;
         Ok(v.try_into()?)
     }
@@ -33,7 +36,10 @@ impl Encode for u16 {
 
 impl<'r> Decode<'r> for u16 {
     fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
-        compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
+        compatible!(
+            value,
+            SqliteDataType::Int | SqliteDataType::Int64 | SqliteDataType::Numeric
+        );
         let v: i32 = value.int()?;
         Ok(v.try_into()?)
     }
@@ -50,7 +56,10 @@ impl Encode for u32 {
 
 impl<'r> Decode<'r> for u32 {
     fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
-        compatible!(value, SqliteDataType::Int | SqliteDataType::Int64);
+        compatible!(
+            value,
+            SqliteDataType::Int | SqliteDataType::Int64 | SqliteDataType::Numeric
+        );
         Ok(value.int64()?.try_into()?)
     }
 }

--- a/crates/musq/tests/types.rs
+++ b/crates/musq/tests/types.rs
@@ -19,6 +19,16 @@ test_type!(f32("3.1410000324249268" == 3.141f32 as f64 as f32));
 
 test_type!(f64("939399419.1225182" == 939399419.1225182_f64));
 
+test_type!(numeric_f64<f64>(
+    "SELECT CAST({0} AS NUMERIC) is CAST(? AS NUMERIC), CAST({0} AS NUMERIC), CAST(? AS NUMERIC)",
+    "CAST(5.5 AS NUMERIC)" == 5.5_f64,
+));
+
+test_type!(numeric_i64<i64>(
+    "SELECT CAST({0} AS NUMERIC) is CAST(? AS NUMERIC), CAST({0} AS NUMERIC), CAST(? AS NUMERIC)",
+    "CAST(1234 AS NUMERIC)" == 1234_i64,
+));
+
 test_type!(str<String>(
     "'this is foo'" == "this is foo",
     "cast(x'7468697320006973206E756C2D636F6E7461696E696E67' as text)" == "this \0is nul-containing",


### PR DESCRIPTION
## Summary
- support `NUMERIC` type in `SqliteDataType`
- allow integer, float and bool decoding from NUMERIC columns
- test numeric affinity detection and round‑trips

## Testing
- `cargo clippy --tests --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687c9274568483338dfe0372ef530ab6