### PR TITLE
Handle connection close errors

### DIFF
--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -83,6 +83,12 @@ impl ConnectionState {
             }
         }
     }
+
+    pub(crate) fn close(&mut self) -> Result<()> {
+        self.statements.clear();
+        self.remove_progress_handler();
+        self.handle.close()
+    }
 }
 
 impl Debug for Connection {


### PR DESCRIPTION
## Summary
- change `ConnectionHandle` to ignore close failures instead of panic
- surface errors from connection shutdown

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c99f9c8c08333b0c95302c0b78ef4