### PR TITLE
Change busy/retry access scope

### DIFF
--- a/crates/musq/src/sqlite/error.rs
+++ b/crates/musq/src/sqlite/error.rs
@@ -243,7 +243,7 @@ impl ExtendedErrCode {
         }
     }
 
-    pub fn is_busy(&self) -> bool {
+    pub(crate) fn is_busy(&self) -> bool {
         matches!(
             self,
             ExtendedErrCode::BusyRecovery
@@ -278,11 +278,11 @@ impl SqliteError {
         }
     }
 
-    pub fn is_busy(&self) -> bool {
+    pub(crate) fn is_busy(&self) -> bool {
         self.primary == PrimaryErrCode::Busy || self.extended.is_busy()
     }
 
-    pub fn should_retry(&self) -> bool {
+    pub(crate) fn should_retry(&self) -> bool {
         self.primary == PrimaryErrCode::Locked
             || self.extended == ExtendedErrCode::LockedSharedCache
             || self.is_busy()


### PR DESCRIPTION
## Summary
- restrict `is_busy` and `should_retry` visibility to `pub(crate)`

## Testing
- `cargo clippy -q`
- `cargo test -p musq --lib --quiet`
- `cargo test -p musq --tests --quiet` *(fails: no method named `lock_handle` found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca1c833e48333b2d804020105bfec