### PR TITLE
Restrict helper visibility

### DIFF
--- a/crates/musq/src/logger.rs
+++ b/crates/musq/src/logger.rs
@@ -72,7 +72,7 @@ macro_rules! private_tracing_dynamic_event {
 }
 
 #[doc(hidden)]
-pub fn private_level_filter_to_levels(
+pub(crate) fn private_level_filter_to_levels(
     filter: log::LevelFilter,
 ) -> Option<(tracing::Level, log::Level)> {
     let tracing_level = match filter {


### PR DESCRIPTION
## Summary
- limit `private_level_filter_to_levels` to crate visibility

## Testing
- `cargo clippy -p musq --lib -- -D warnings`
- `cargo test --workspace --lib` *(fails: could not compile `musq` (test "invalid_utf8") due to missing method `lock_handle`)*

------
https://chatgpt.com/codex/tasks/task_e_687ca1d241b48333b19a87542714083f