### PR TITLE
Mark SQLite enums as non_exhaustive

### DIFF
--- a/crates/musq/src/sqlite/error.rs
+++ b/crates/musq/src/sqlite/error.rs
@@ -6,8 +6,12 @@ use libsqlite3_sys::{self, sqlite3};
 // Error Codes And Messages
 // https://www.sqlite.org/c3ref/errcode.html
 
-/// Primary Sqlite error codes
+/// Primary Sqlite error codes.
+///
+/// **Note:** This enum is marked `#[non_exhaustive]`; avoid exhaustive
+/// matches as new variants may be introduced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub(crate) enum PrimaryErrCode {
     Error,
     Internal,
@@ -76,8 +80,12 @@ impl PrimaryErrCode {
     }
 }
 
-/// Extended Sqlite error codes
+/// Extended Sqlite error codes.
+///
+/// **Note:** This enum is marked `#[non_exhaustive]`; avoid exhaustive
+/// matches as new variants may be introduced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub(crate) enum ExtendedErrCode {
     ErrorMissingCollseq,
     ErrorRetry,
@@ -288,10 +296,12 @@ impl SqliteError {
             || self.is_busy()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn primary_code(&self) -> PrimaryErrCode {
         self.primary
     }
 
+    #[allow(dead_code)]
     pub(crate) fn extended_code(&self) -> ExtendedErrCode {
         self.extended
     }

--- a/crates/musq/src/sqlite/type_info.rs
+++ b/crates/musq/src/sqlite/type_info.rs
@@ -4,7 +4,11 @@ use std::str::FromStr;
 use libsqlite3_sys::{SQLITE_BLOB, SQLITE_FLOAT, SQLITE_INTEGER, SQLITE_NULL, SQLITE_TEXT};
 
 /// Data types supported by SQLite.
+///
+/// **Note:** This enum is marked `#[non_exhaustive]`; additional variants
+/// may be added in the future. Avoid exhaustive matching.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum SqliteDataType {
     Null,
     Int,

--- a/crates/musq/src/sqlite/value.rs
+++ b/crates/musq/src/sqlite/value.rs
@@ -11,7 +11,11 @@ use crate::{error::DecodeError, sqlite::type_info::SqliteDataType};
 /// The variants closely mirror SQLite's dynamic typing system and allow a
 /// single enum to capture every value that can be transferred between the
 /// database and user code.
+///
+/// **Note:** This enum is marked `#[non_exhaustive]`; do not match on it
+/// exhaustively as more variants may be added in the future.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Value {
     /// A NULL value. If the original column declared a specific type the
     /// information is stored in `type_info` for use during decoding.


### PR DESCRIPTION
## Summary
- mark `Value`, `SqliteDataType`, `PrimaryErrCode` and `ExtendedErrCode` as `#[non_exhaustive]`
- note in the docs that these enums should not be exhaustively matched
- silence Clippy dead code warnings in `SqliteError`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687ca97075e88333b2ea1a559e479a86