### PR TITLE
Seal Execute trait

### DIFF
--- a/crates/musq/src/executor.rs
+++ b/crates/musq/src/executor.rs
@@ -1,13 +1,27 @@
 use crate::{Arguments, Statement};
 
+// Private module that defines the `Sealed` trait used to prevent external
+// implementations of [`Execute`].
+mod sealed {
+    /// Prevent downstream implementations of [`Execute`].
+    pub trait Sealed {}
+
+    impl Sealed for &str {}
+    impl Sealed for crate::query::Query {}
+    impl<F> Sealed for crate::query::Map<F> {}
+}
+
 /// A type that may be executed against a database connection.
+///
+/// This trait is **sealed** and cannot be implemented outside of this crate.
 ///
 /// Implemented for the following:
 ///
 ///  * [`&str`](std::str)
 ///  * [`Query`](super::query::Query)
+///  * [`Map<F>`](super::query::Map)
 ///
-pub trait Execute: Send + Sized {
+pub trait Execute: sealed::Sealed + Send + Sized {
     /// Gets the SQL that will be executed.
     fn sql(&self) -> &str;
 

--- a/crates/musq/src/sqlite/error.rs
+++ b/crates/musq/src/sqlite/error.rs
@@ -288,10 +288,12 @@ impl SqliteError {
             || self.is_busy()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn primary_code(&self) -> PrimaryErrCode {
         self.primary
     }
 
+    #[allow(dead_code)]
     pub(crate) fn extended_code(&self) -> ExtendedErrCode {
         self.extended
     }


### PR DESCRIPTION
## Summary
- seal the `Execute` trait with a private `sealed` module
- allow unused error helper methods

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_687ca9564f148333ab766a93a683130b