### PR TITLE
Make columns field crate-private

### DIFF
--- a/crates/musq/src/sqlite/statement/mod.rs
+++ b/crates/musq/src/sqlite/statement/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use handle::StatementHandle;
 #[allow(clippy::rc_buffer)]
 pub struct Statement {
     pub(crate) sql: String,
-    pub columns: Arc<Vec<Column>>,
+    pub(crate) columns: Arc<Vec<Column>>,
 }
 
 impl Statement {

--- a/crates/musq/tests/sqlite.rs
+++ b/crates/musq/tests/sqlite.rs
@@ -525,15 +525,15 @@ async fn it_can_prepare_then_execute() -> anyhow::Result<()> {
 
     let statement = tx.prepare("SELECT * FROM tweet WHERE id = ?1").await?;
 
-    assert_eq!(statement.columns[0].name(), "id");
-    assert_eq!(statement.columns[1].name(), "text");
-    assert_eq!(statement.columns[2].name(), "is_sent");
-    assert_eq!(statement.columns[3].name(), "owner_id");
+    assert_eq!(statement.columns()[0].name(), "id");
+    assert_eq!(statement.columns()[1].name(), "text");
+    assert_eq!(statement.columns()[2].name(), "is_sent");
+    assert_eq!(statement.columns()[3].name(), "owner_id");
 
-    assert_eq!(statement.columns[0].type_info().name(), "INTEGER");
-    assert_eq!(statement.columns[1].type_info().name(), "TEXT");
-    assert_eq!(statement.columns[2].type_info().name(), "BOOLEAN");
-    assert_eq!(statement.columns[3].type_info().name(), "INTEGER");
+    assert_eq!(statement.columns()[0].type_info().name(), "INTEGER");
+    assert_eq!(statement.columns()[1].type_info().name(), "TEXT");
+    assert_eq!(statement.columns()[2].type_info().name(), "BOOLEAN");
+    assert_eq!(statement.columns()[3].type_info().name(), "INTEGER");
 
     let row = statement.query().bind(tweet_id).fetch_one(&mut tx).await?;
     let tweet_text: &str = row.get_value("text")?;
@@ -562,7 +562,7 @@ async fn it_handles_numeric_affinity() -> anyhow::Result<()> {
         .prepare("SELECT price FROM products WHERE product_no = ?")
         .await?;
 
-    assert_eq!(stmt.columns[0].type_info().name(), "NUMERIC");
+    assert_eq!(stmt.columns()[0].type_info().name(), "NUMERIC");
 
     let row = stmt.query().bind(1_i32).fetch_one(&mut conn).await?;
     let price: f64 = row.get_value_idx(0)?;


### PR DESCRIPTION
## Summary
- hide `Statement::columns` behind pub(crate) visibility
- use the `columns()` accessor in sqlite tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687cafb0843c83338f79e258aa2d8b3a