### PR TITLE
Annotate close futures with #[must_use]

### DIFF
--- a/crates/musq/src/pool/connection.rs
+++ b/crates/musq/src/pool/connection.rs
@@ -57,6 +57,10 @@ impl PoolConnection {
     ///
     /// The connection permit is retained for the duration so the pool will not
     /// exceed `max_connections`.
+    ///
+    /// The returned future **must** be awaited to ensure the connection is
+    /// fully closed.
+    #[must_use = "futures returned by `PoolConnection::close` must be awaited"]
     pub async fn close(mut self) -> Result<()> {
         let floating = self.take_live().float(self.pool.clone());
         floating.inner.raw.close().await

--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -133,6 +133,10 @@ impl Pool {
     /// internally and so may be unpredictable otherwise.
     ///
     /// `.close()` may be safely called and `.await`ed on multiple handles concurrently.
+    ///
+    /// The returned future **must** be awaited to ensure the pool is fully
+    /// closed.
+    #[must_use = "futures returned by `Pool::close` must be awaited"]
     pub async fn close(&self) {
         self.0.close().await
     }

--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -89,6 +89,10 @@ impl Connection {
     ///
     /// Therefore it is recommended to call `.close()` on a connection when you are done using it
     /// and to `.await` the result to ensure the termination message is sent.
+    ///
+    /// The returned future **must** be awaited to ensure the connection is fully
+    /// closed.
+    #[must_use = "futures returned by `Connection::close` must be awaited"]
     pub async fn close(mut self) -> Result<()> {
         if let OptimizeOnClose::Enabled { analysis_limit } = self.optimize_on_close {
             let mut pragma_string = String::new();

--- a/crates/musq/src/sqlite/error.rs
+++ b/crates/musq/src/sqlite/error.rs
@@ -295,5 +295,4 @@ impl SqliteError {
             || self.extended == ExtendedErrCode::LockedSharedCache
             || self.is_busy()
     }
-
 }

--- a/crates/musq/src/sqlite/statement/handle.rs
+++ b/crates/musq/src/sqlite/statement/handle.rs
@@ -124,7 +124,6 @@ impl StatementHandle {
         )
     }
 
-
     pub(crate) fn bind_int64(&self, index: usize, v: i64) -> std::result::Result<(), SqliteError> {
         ffi::bind_int64(self.0.as_ptr(), index as i32, v)
     }


### PR DESCRIPTION
## Summary
- require awaiting of the futures returned by `PoolConnection::close`, `Pool::close` and `Connection::close`
- document the need to await these futures

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687caf9b9334833393fc91e6c75d2b02