### PR TITLE
Restrict Pool size visibility

### DIFF
--- a/crates/musq/src/pool/mod.rs
+++ b/crates/musq/src/pool/mod.rs
@@ -154,12 +154,12 @@ impl Pool {
     }
 
     /// Returns the number of connections currently active. This includes idle connections.
-    pub fn size(&self) -> u32 {
+    pub(crate) fn size(&self) -> u32 {
         self.0.size()
     }
 
     /// Returns the number of connections active and idle (not in use).
-    pub fn num_idle(&self) -> usize {
+    pub(crate) fn num_idle(&self) -> usize {
         // This previously called [`crossbeam::queue::ArrayQueue::len()`] which waits for the head and tail pointers to
         // be in a consistent state, which may never happen at high levels of churn.
         self.0.num_idle()
@@ -274,8 +274,8 @@ impl Clone for Pool {
 impl fmt::Debug for Pool {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Pool")
-            .field("size", &self.0.size())
-            .field("num_idle", &self.0.num_idle())
+            .field("size", &self.size())
+            .field("num_idle", &self.num_idle())
             .field("is_closed", &self.0.is_closed())
             .field("options", &self.0.options)
             .finish()


### PR DESCRIPTION
## Summary
- make `Pool::size` and `Pool::num_idle` internal
- update Debug implementation to use the new methods

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`


------
https://chatgpt.com/codex/tasks/task_e_687cb094ca248333958f94c2faeb57b4