### PR TITLE
Hide pool module, re-export Pool types

### DIFF
--- a/crates/musq/src/error.rs
+++ b/crates/musq/src/error.rs
@@ -86,14 +86,14 @@ pub enum Error {
     /// A [`Pool::acquire`] timed out due to connections not becoming available or
     /// because another task encountered too many errors while trying to open a new connection.
     ///
-    /// [`Pool::acquire`]: crate::pool::Pool::acquire
+    /// [`Pool::acquire`]: crate::Pool::acquire
     #[error("pool timed out while waiting for an open connection")]
     PoolTimedOut,
 
     /// [`Pool::close`] was called while we were waiting in [`Pool::acquire`].
     ///
-    /// [`Pool::acquire`]: crate::pool::Pool::acquire
-    /// [`Pool::close`]: crate::pool::Pool::close
+    /// [`Pool::acquire`]: crate::Pool::acquire
+    /// [`Pool::close`]: crate::Pool::close
     #[error("attempted to acquire a connection on a closed pool")]
     PoolClosed,
 

--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -15,7 +15,7 @@ mod from_row;
 #[macro_use]
 mod logger;
 mod musq;
-pub mod pool;
+mod pool;
 pub mod query;
 mod query_result;
 mod row;
@@ -30,7 +30,7 @@ pub use crate::{
     executor::Execute,
     from_row::FromRow,
     musq::{AutoVacuum, JournalMode, LockingMode, Musq, Synchronous},
-    pool::Pool,
+    pool::{Pool, PoolConnection},
     query::{query, query_as, query_as_with, query_scalar, query_scalar_with, query_with},
     query_result::QueryResult,
     row::Row,

--- a/crates/musq/src/pool/connection.rs
+++ b/crates/musq/src/pool/connection.rs
@@ -7,7 +7,7 @@ use crate::{Connection, Result};
 use super::inner::{DecrementSizeGuard, PoolInner};
 use std::future::Future;
 
-/// A connection managed by a [`Pool`][crate::pool::Pool].
+/// A connection managed by a [`Pool`][crate::Pool].
 ///
 /// Will be returned to the pool on-drop.
 pub struct PoolConnection {
@@ -92,7 +92,7 @@ impl PoolConnection {
     }
 }
 
-/// Returns the connection to the [`Pool`][crate::pool::Pool] it was checked-out from.
+/// Returns the connection to the [`Pool`][crate::Pool] it was checked-out from.
 impl Drop for PoolConnection {
     fn drop(&mut self) {
         // We still need to spawn a task to maintain `min_connections`.

--- a/crates/musq/src/transaction.rs
+++ b/crates/musq/src/transaction.rs
@@ -19,7 +19,7 @@ use crate::{Connection, Result};
 /// established to be rolled back, restoring the transaction state to what it was at the time of the savepoint.
 ///
 /// [`Connection::begin`]: crate::connection::Connection::begin()
-/// [`Pool::begin`]: crate::pool::Pool::begin()
+/// [`Pool::begin`]: crate::Pool::begin()
 /// [`commit`]: Self::commit()
 /// [`rollback`]: Self::rollback()
 pub struct Transaction<C>


### PR DESCRIPTION
## Summary
- hide the `pool` module from public API
- re-export `PoolConnection` alongside `Pool`
- update docs to reference re-exported `Pool` and `PoolConnection`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687cb27491908333b809c26b2e18afab