### PR TITLE
Limit statement cache internals to crate

### DIFF
--- a/crates/musq/src/sqlite/connection/mod.rs
+++ b/crates/musq/src/sqlite/connection/mod.rs
@@ -111,14 +111,15 @@ impl Connection {
         Transaction::begin(self)
     }
 
-    pub fn cached_statements_size(&self) -> usize {
+    pub(crate) fn cached_statements_size(&self) -> usize {
         self.worker
             .shared
             .cached_statements_size
             .load(std::sync::atomic::Ordering::Acquire)
     }
 
-    pub async fn clear_cached_statements(&mut self) -> Result<()> {
+    #[cfg(test)]
+    pub(crate) async fn clear_cached_statements(&mut self) -> Result<()> {
         self.worker.clear_cache().await?;
         Ok(())
     }

--- a/crates/musq/src/sqlite/connection/worker.rs
+++ b/crates/musq/src/sqlite/connection/worker.rs
@@ -55,6 +55,7 @@ enum Command {
     Rollback {
         tx: Option<rendezvous_oneshot::Sender<Result<()>>>,
     },
+    #[cfg(test)]
     ClearCache {
         tx: oneshot::Sender<()>,
     },
@@ -220,6 +221,7 @@ impl ConnectionWorker {
                                 ignore_next_start_rollback = true;
                             }
                         }
+                        #[cfg(test)]
                         Command::ClearCache { tx } => {
                             conn.statements.clear();
                             update_cached_statements_size(&conn, &shared.cached_statements_size);
@@ -331,6 +333,7 @@ impl ConnectionWorker {
         rx.recv().await.map_err(|_| Error::WorkerCrashed)
     }
 
+    #[cfg(test)]
     pub(crate) async fn clear_cache(&mut self) -> Result<()> {
         self.oneshot_cmd(|tx| Command::ClearCache { tx }).await
     }

--- a/crates/musq/src/statement_cache.rs
+++ b/crates/musq/src/statement_cache.rs
@@ -107,6 +107,9 @@ mod tests {
         assert_eq!(v2, 5);
         assert_eq!(conn.cached_statements_size(), initial + 1);
 
+        conn.clear_cached_statements().await?;
+        assert_eq!(conn.cached_statements_size(), 0);
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- restrict visibility of `cached_statements_size` and `clear_cached_statements`
- adapt statement cache tests to call helper internally
- update integration tests to validate behaviour without private helpers
- gate statement cache clearing APIs to `#[cfg(test)]`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687cb08ce63c8333b48713150b46a972