### PR TITLE
Add Arc blob example and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,14 @@ If `s` is a `&str` reference, Musq has to clone the value into an owned structur
 thread sharing. This is usually fine, but if `s` is large, we can avoid the copy by passing an owned `String` or an
 `Arc<String>` instead. The same idea holds for the reference `&[u8]` and its counterparts `Vec<u8>` and `Arc<Vec<u8>>`.
 
-FIXME: Add note on efficiently querying large blobs
+When fetching large blobs you can decode directly into an `Arc<Vec<u8>>` to
+reduce copying and easily share the data:
+
+```rust
+let blob: Arc<Vec<u8>> = query_scalar("SELECT data FROM blob_test")
+    .fetch_one(&mut conn)
+    .await?;
+```
 
 ## Named parameters
 

--- a/crates/musq/src/types/bytes.rs
+++ b/crates/musq/src/types/bytes.rs
@@ -36,9 +36,15 @@ impl<'r> Decode<'r> for Vec<u8> {
 
 impl Encode for Arc<Vec<u8>> {
     fn encode(self) -> Value {
-        Value::Blob {
-            value: (*self).clone(),
-            type_info: None,
+        match Arc::try_unwrap(self) {
+            Ok(v) => Value::Blob {
+                value: v,
+                type_info: None,
+            },
+            Err(arc) => Value::Blob {
+                value: (*arc).clone(),
+                type_info: None,
+            },
         }
     }
 }

--- a/crates/musq/src/types/str.rs
+++ b/crates/musq/src/types/str.rs
@@ -36,9 +36,15 @@ impl<'r> Decode<'r> for String {
 
 impl Encode for Arc<String> {
     fn encode(self) -> Value {
-        Value::Text {
-            value: (*self).clone().into_bytes(),
-            type_info: None,
+        match Arc::try_unwrap(self) {
+            Ok(s) => Value::Text {
+                value: s.into_bytes(),
+                type_info: None,
+            },
+            Err(arc) => Value::Text {
+                value: arc.as_bytes().to_vec(),
+                type_info: None,
+            },
         }
     }
 }

--- a/crates/musq/tests/large_blob.rs
+++ b/crates/musq/tests/large_blob.rs
@@ -1,0 +1,24 @@
+use musq::{query, query_scalar};
+use musq_test::connection;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn insert_and_select_arc_blob() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    conn.execute("CREATE TABLE blob_test (data BLOB)").await?;
+
+    let data: Vec<u8> = vec![0x42; 16 * 1024];
+    let arc = Arc::new(data.clone());
+
+    query("INSERT INTO blob_test (data) VALUES (?)")
+        .bind(Arc::clone(&arc))
+        .execute(&mut conn)
+        .await?;
+
+    let returned: Arc<Vec<u8>> = query_scalar("SELECT data FROM blob_test")
+        .fetch_one(&mut conn)
+        .await?;
+
+    assert_eq!(*returned, data);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- allow `Arc<String>` and `Arc<Vec<u8>>` parameters to avoid a clone when unique
- document and test using `Arc<Vec<u8>>` for large blobs

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687cf30a74788333a5555f60d885616d