### PR TITLE
Support generics in derived enums

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -34,7 +34,9 @@ fn setup() -> musq::Pool {
         let p = pool().await;
         musq::query("INSERT INTO data (a, b) VALUES (?1, ?2)")
             .bind(1)
+            .unwrap()
             .bind("two")
+            .unwrap()
             .execute(&mut p.acquire().await.unwrap())
             .await
             .unwrap();
@@ -51,7 +53,9 @@ async fn writes(pool: musq::Pool) {
             let mut conn = pool.acquire().await.unwrap();
             musq::query("INSERT INTO data (a, b) VALUES (?1, ?2)")
                 .bind(1)
+                .unwrap()
                 .bind("two")
+                .unwrap()
                 .execute(&mut conn)
                 .await
         });

--- a/crates/musq-macros/src/tests/decode.rs
+++ b/crates/musq-macros/src/tests/decode.rs
@@ -11,6 +11,14 @@ fn derive_enum() {
 }
 
 #[test]
+fn derive_enum_generic() {
+    let input = parse_str("enum Foo<T> { One(T), Two }").unwrap();
+    let tokens = expand_derive_decode(&input).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl < 'r , T > musq :: decode :: Decode < 'r > for Foo < T >"));
+}
+
+#[test]
 fn derive_enum_with_repr() {
     let input = parse_str("#[musq(repr = \"i32\")] enum Foo { One, Two }").unwrap();
     let tokens = expand_derive_decode(&input).unwrap();

--- a/crates/musq-macros/src/tests/encode.rs
+++ b/crates/musq-macros/src/tests/encode.rs
@@ -12,6 +12,14 @@ fn derive_enum() {
 }
 
 #[test]
+fn derive_enum_generic() {
+    let input = parse_str("enum Foo<T> { One(T), Two }").unwrap();
+    let tokens = expand_derive_encode(&input).unwrap();
+    let s = tokens.to_string();
+    assert!(s.contains("impl < T > musq :: encode :: Encode for Foo < T >"));
+}
+
+#[test]
 fn derive_enum_with_repr() {
     let input = parse_str("#[musq(repr = \"i32\")] enum Foo { One, Two }").unwrap();
     let tokens = expand_derive_encode(&input).unwrap();

--- a/crates/musq/src/sqlite/connection/handle.rs
+++ b/crates/musq/src/sqlite/connection/handle.rs
@@ -84,13 +84,13 @@ impl ConnectionHandle {
 impl Drop for ConnectionHandle {
     fn drop(&mut self) {
         // https://sqlite.org/c3ref/close.html
-        if !self.closed {
-            if let Err(e) = ffi::close(self.ptr.as_ptr()) {
-                // This should only happen if SQLite has leaked handles internally
-                // or we misused the API. Log the error and the connection pointer
-                // so that we can troubleshoot the issue if it happens in the wild.
-                tracing::error!(db_ptr = ?self.ptr, "sqlite3_close failed: {}", e);
-            }
+        if !self.closed
+            && let Err(e) = ffi::close(self.ptr.as_ptr())
+        {
+            // This should only happen if SQLite has leaked handles internally
+            // or we misused the API. Log the error and the connection pointer
+            // so that we can troubleshoot the issue if it happens in the wild.
+            tracing::error!(db_ptr = ?self.ptr, "sqlite3_close failed: {}", e);
         }
     }
 }

--- a/crates/musq/src/types/time.rs
+++ b/crates/musq/src/types/time.rs
@@ -264,7 +264,7 @@ mod tests {
                 assert_eq!(dt, expected);
             }
             Err(e) => {
-                println!("Failed to parse '2023-12-25 15:30:45+05:30': {}", e);
+                println!("Failed to parse '2023-12-25 15:30:45+05:30': {e}");
                 // This reveals the bug
             }
         }
@@ -300,8 +300,8 @@ mod tests {
             let result: Result<OffsetDateTime, _> = Decode::decode(&value);
 
             match result {
-                Ok(_) => println!("✓ Valid format correctly parsed: {}", format_str),
-                Err(e) => panic!("Valid format failed to parse {}: {}", format_str, e),
+                Ok(_) => println!("✓ Valid format correctly parsed: {format_str}"),
+                Err(e) => panic!("Valid format failed to parse {format_str}: {e}"),
             }
         }
     }
@@ -329,10 +329,7 @@ mod tests {
                 assert_eq!(dt.offset(), time::UtcOffset::UTC);
             }
             Err(e) => {
-                panic!(
-                    "Failed to parse valid RFC3339 format '{}': {}",
-                    problematic_format, e
-                );
+                panic!("Failed to parse valid RFC3339 format '{problematic_format}': {e}");
             }
         }
 
@@ -353,7 +350,7 @@ mod tests {
 
             match result {
                 Ok(_) => {} // Success is expected
-                Err(e) => panic!("Failed to parse valid format '{}': {}", format_str, e),
+                Err(e) => panic!("Failed to parse valid format '{format_str}': {e}"),
             }
         }
     }


### PR DESCRIPTION
## Summary
- support generics in `Encode` and `Decode` derives for enums
- add coverage for enums with type parameters
- fix clippy warnings in codebase

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6880484d0f308333b958dcbf7299e41d