### PR TITLE
Add trybuild tests for macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1159,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -1647,6 +1654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,7 +1724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d7b3e8a3b6f2ee93ac391a0f757c13790caa0147892e3545cd549dd5b54bc0"
 dependencies = [
  "unicode_categories",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -1787,6 +1803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1829,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1912,6 +1943,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.12",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow 0.7.12",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,6 +2011,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65af40ad689f2527aebbd37a0a816aea88ff5f774ceabe99de5be02f2f91dae2"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -2287,6 +2372,12 @@ checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/crates/musq-macros/Cargo.toml
+++ b/crates/musq-macros/Cargo.toml
@@ -22,3 +22,4 @@ syn = "2.0.39"
 musq = { path = "../musq" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+trybuild = "1.0"

--- a/crates/musq-macros/tests/derive.rs
+++ b/crates/musq-macros/tests/derive.rs
@@ -1,0 +1,6 @@
+#[test]
+fn derive() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/trybuild/pass_*.rs");
+    t.compile_fail("tests/trybuild/fail_*.rs");
+}

--- a/crates/musq-macros/tests/trybuild/fail_codec.rs
+++ b/crates/musq-macros/tests/trybuild/fail_codec.rs
@@ -1,0 +1,6 @@
+use musq::Codec;
+
+#[derive(Codec)]
+struct Bad { a: i32 }
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/fail_codec.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_codec.stderr
@@ -1,0 +1,5 @@
+error: structs must have exactly one unnamed field
+ --> tests/trybuild/fail_codec.rs:4:1
+  |
+4 | struct Bad { a: i32 }
+  | ^^^^^^^^^^^^^^^^^^^^^

--- a/crates/musq-macros/tests/trybuild/fail_codec_enum.rs
+++ b/crates/musq-macros/tests/trybuild/fail_codec_enum.rs
@@ -1,0 +1,8 @@
+use musq::Codec;
+
+#[derive(Codec)]
+enum Bad<'a, T> {
+    A(&'a T),
+}
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
@@ -1,0 +1,42 @@
+error[E0532]: expected unit struct, unit variant or constant, found tuple variant `Bad::A`
+ --> tests/trybuild/fail_codec_enum.rs:4:6
+  |
+4 |   enum Bad<'a, T> {
+  |  ______^
+5 | |     A(&'a T),
+  | |     ^-------
+  | |     |
+  | |_____`Bad::A` defined here
+  |       help: use the tuple variant pattern syntax instead: `Bad::A(_)`
+
+error[E0308]: mismatched types
+ --> tests/trybuild/fail_codec_enum.rs:4:6
+  |
+3 |   #[derive(Codec)]
+  |            ----- arguments to this enum variant are incorrect
+4 |   enum Bad<'a, T> {
+  |  ______^
+5 | |     A(&'a T),
+  | |     ^
+  | |     |
+  | |_____`A` defines an enum variant constructor here, which should be called
+  |       expected `Bad<'_, T>`, found enum constructor
+  |
+  = note:          expected enum `Bad<'_, T>`
+          found enum constructor `fn(&_) -> Bad<'_, _> {Bad::<'_, _>::A}`
+help: the type constructed contains `fn(&_) -> Bad<'_, _> {Bad::<'_, _>::A}` due to the type of the argument passed
+ --> tests/trybuild/fail_codec_enum.rs:3:10
+  |
+3 |   #[derive(Codec)]
+  |            ^^^^^
+4 |   enum Bad<'a, T> {
+  |  ______-
+5 | |     A(&'a T),
+  | |_____- this argument influences the type of `Ok`
+note: tuple variant defined here
+ --> $RUST/core/src/result.rs
+  = note: this error originates in the derive macro `Codec` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use parentheses to construct this tuple variant
+  |
+5 |     A(/* value */)(&'a T),
+  |      +++++++++++++

--- a/crates/musq-macros/tests/trybuild/fail_decode.rs
+++ b/crates/musq-macros/tests/trybuild/fail_decode.rs
@@ -1,0 +1,6 @@
+use musq::Decode;
+
+#[derive(Decode)]
+struct Bad { a: i32 }
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/fail_decode.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_decode.stderr
@@ -1,0 +1,5 @@
+error: structs must have exactly one unnamed field
+ --> tests/trybuild/fail_decode.rs:4:1
+  |
+4 | struct Bad { a: i32 }
+  | ^^^^^^^^^^^^^^^^^^^^^

--- a/crates/musq-macros/tests/trybuild/fail_encode.rs
+++ b/crates/musq-macros/tests/trybuild/fail_encode.rs
@@ -1,0 +1,6 @@
+use musq::Encode;
+
+#[derive(Encode)]
+struct Bad { a: i32 }
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/fail_encode.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_encode.stderr
@@ -1,0 +1,5 @@
+error: structs must have exactly one unnamed field
+ --> tests/trybuild/fail_encode.rs:4:1
+  |
+4 | struct Bad { a: i32 }
+  | ^^^^^^^^^^^^^^^^^^^^^

--- a/crates/musq-macros/tests/trybuild/fail_from_row.rs
+++ b/crates/musq-macros/tests/trybuild/fail_from_row.rs
@@ -1,0 +1,6 @@
+use musq::FromRow;
+
+#[derive(FromRow)]
+struct Bad;
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/fail_from_row.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_from_row.stderr
@@ -1,0 +1,7 @@
+error: Unsupported shape `no fields`. Expected named fields or unnamed fields.
+ --> tests/trybuild/fail_from_row.rs:3:10
+  |
+3 | #[derive(FromRow)]
+  |          ^^^^^^^
+  |
+  = note: this error originates in the derive macro `FromRow` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/fail_json.rs
+++ b/crates/musq-macros/tests/trybuild/fail_json.rs
@@ -1,0 +1,8 @@
+use musq::Json;
+
+#[derive(Json)]
+enum Bad {
+    A,
+}
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/fail_json.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_json.stderr
@@ -1,0 +1,7 @@
+error: Unsupported shape `enum`. Expected struct with named fields or unnamed fields.
+ --> tests/trybuild/fail_json.rs:3:10
+  |
+3 | #[derive(Json)]
+  |          ^^^^
+  |
+  = note: this error originates in the derive macro `Json` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/pass_codec.rs
+++ b/crates/musq-macros/tests/trybuild/pass_codec.rs
@@ -1,0 +1,9 @@
+use musq::Codec;
+
+#[derive(Codec)]
+enum Enum {
+    A,
+    B,
+}
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/pass_decode.rs
+++ b/crates/musq-macros/tests/trybuild/pass_decode.rs
@@ -1,0 +1,6 @@
+use musq::Decode;
+
+#[derive(Decode)]
+struct NewType(i32);
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/pass_encode.rs
+++ b/crates/musq-macros/tests/trybuild/pass_encode.rs
@@ -1,0 +1,6 @@
+use musq::Encode;
+
+#[derive(Encode)]
+struct NewType(i32);
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/pass_from_row.rs
+++ b/crates/musq-macros/tests/trybuild/pass_from_row.rs
@@ -1,0 +1,9 @@
+use musq::FromRow;
+
+#[derive(FromRow)]
+struct Record<'r, T> {
+    a: &'r T,
+    b: i32,
+}
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/pass_json.rs
+++ b/crates/musq-macros/tests/trybuild/pass_json.rs
@@ -1,0 +1,9 @@
+use musq::Json;
+use serde::{Deserialize, Serialize};
+
+#[derive(Json, Serialize, Deserialize)]
+struct Generic {
+    val: String,
+}
+
+fn main() {}


### PR DESCRIPTION
## Summary
- introduce integration tests for musq-macros using trybuild
- provide passing and failing compile cases for derive macros
- ensure generic structs with lifetimes are tested
- add trybuild dev-dependency

## Testing
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68804c175c888333a77930a72002deae