### PR TITLE
Remove musq dev-dependency from macros crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,6 @@ version = "0.0.1"
 dependencies = [
  "darling",
  "heck",
- "musq",
  "proc-macro2",
  "quote",
  "serde",

--- a/crates/musq-macros/Cargo.toml
+++ b/crates/musq-macros/Cargo.toml
@@ -19,6 +19,5 @@ quote = "1.0.33"
 syn = "2.0.39"
 
 [dev-dependencies]
-musq = { path = "../musq" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary
- remove `musq` dev-dependency from `musq-macros`

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all --quiet`
- `cargo test -p musq-macros`


------
https://chatgpt.com/codex/tasks/task_e_68804d6a4e988333aa9a2b298b818992