### PR TITLE
Refactor common enum name logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ version = "0.0.1"
 dependencies = [
  "darling",
  "heck",
+ "musq",
  "proc-macro2",
  "quote",
  "serde",

--- a/crates/musq-macros/Cargo.toml
+++ b/crates/musq-macros/Cargo.toml
@@ -22,3 +22,4 @@ syn = "2.0.39"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trybuild = "1.0"
+musq = { path = "../musq" }

--- a/crates/musq-macros/src/core.rs
+++ b/crates/musq-macros/src/core.rs
@@ -117,6 +117,15 @@ pub struct TypeVariant {
     pub rename: Option<String>,
 }
 
+/// Returns the canonical name of an enum variant after applying any
+/// `rename` attribute or container level `rename_all` rule.
+pub(crate) fn variant_name(container: &TypeContainer, variant: &TypeVariant) -> String {
+    variant
+        .rename
+        .clone()
+        .unwrap_or_else(|| container.rename_all.rename(&variant.ident.to_string()))
+}
+
 #[derive(Debug, FromField)]
 #[darling(attributes(musq))]
 pub struct TypeField {

--- a/crates/musq-macros/src/decode.rs
+++ b/crates/musq-macros/src/decode.rs
@@ -108,13 +108,8 @@ fn expand_enum(
 
     let value_arms = variants.iter().map(|v| -> Arm {
         let id = &v.ident;
-        if let Some(rename) = &v.rename {
-            parse_quote!(#rename => ::std::result::Result::Ok(#ident :: #id),)
-        } else {
-            let name = container.rename_all.rename(&id.to_string());
-
-            parse_quote!(#name => ::std::result::Result::Ok(#ident :: #id),)
-        }
+        let name = core::variant_name(container, v);
+        parse_quote!(#name => ::std::result::Result::Ok(#ident :: #id),)
     });
 
     let values = quote! {

--- a/crates/musq-macros/src/encode.rs
+++ b/crates/musq-macros/src/encode.rs
@@ -15,17 +15,11 @@ fn expand_enum(
     let ident = &container.ident;
     let generics = &container.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let mut value_arms = Vec::new();
-
-    for v in variants {
+    let value_arms = variants.iter().map(|v| {
         let id = &v.ident;
-        if let Some(rename) = &v.rename {
-            value_arms.push(quote!(#ident :: #id => #rename,));
-        } else {
-            let name = container.rename_all.rename(&id.to_string());
-            value_arms.push(quote!(#ident :: #id => #name,));
-        }
-    }
+        let name = core::variant_name(container, v);
+        quote!(#ident :: #id => #name,)
+    });
 
     Ok(quote!(
         #[automatically_derived]


### PR DESCRIPTION
## Summary
- extract `variant_name` helper to centralize enum variant renaming rules
- refactor encode/decode macro generators to use new helper
- add musq as dev-dependency for macro tests

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688051d928f4833383379439e0e9a771