### PR TITLE
Map TryFrom errors to ColumnDecode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ version = "0.0.1"
 dependencies = [
  "darling",
  "heck",
+ "musq",
  "proc-macro2",
  "quote",
  "serde",

--- a/crates/musq-macros/Cargo.toml
+++ b/crates/musq-macros/Cargo.toml
@@ -22,3 +22,4 @@ syn = "2.0.39"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trybuild = "1.0"
+musq = { path = "../musq" }

--- a/crates/musq/src/sqlite/value.rs
+++ b/crates/musq/src/sqlite/value.rs
@@ -1,4 +1,4 @@
-use crate::{error::DecodeError, sqlite::type_info::SqliteDataType};
+use crate::{decode::Decode, error::DecodeError, sqlite::type_info::SqliteDataType};
 
 /// Owned representation of a SQLite value.
 ///
@@ -127,5 +127,11 @@ impl Value {
     /// Returns `true` if the value is [`Value::Null`].
     pub fn is_null(&self) -> bool {
         matches!(self, Value::Null { .. })
+    }
+}
+
+impl<'r> Decode<'r> for Value {
+    fn decode(value: &'r Value) -> std::result::Result<Self, DecodeError> {
+        Ok(value.clone())
     }
 }

--- a/crates/musq/tests/try_from.rs
+++ b/crates/musq/tests/try_from.rs
@@ -1,0 +1,34 @@
+use musq::{Error, Value, query_as};
+use musq_macros::*;
+use musq_test::connection;
+
+#[derive(Debug, FromRow, PartialEq)]
+struct Foo {
+    #[musq(try_from = "i64")]
+    value: u64,
+}
+
+#[tokio::test]
+async fn try_from_failure_maps_error() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+
+    let res: musq::Result<Foo> = query_as::<Foo>("SELECT -1 as value")
+        .fetch_one(&mut conn)
+        .await;
+
+    let err = res.expect_err("expected failure");
+    if let Error::ColumnDecode {
+        column_name, value, ..
+    } = err
+    {
+        assert_eq!(column_name, "value");
+        match value {
+            Value::Integer { value, .. } => assert_eq!(value, -1),
+            other => panic!("unexpected value: {other:?}"),
+        }
+    } else {
+        panic!("unexpected error: {err:?}");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- return column decode error when `try_from` conversions fail in `FromRow`
- support decoding into raw `Value`
- ensure macro tests have musq as a dev dependency
- test `try_from` error handling

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_688052345d8c83338944d5d2cc0b023f