### PR TITLE
Check conflicting FromRow attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ version = "0.0.1"
 dependencies = [
  "darling",
  "heck",
+ "musq",
  "proc-macro2",
  "quote",
  "serde",

--- a/crates/musq-macros/Cargo.toml
+++ b/crates/musq-macros/Cargo.toml
@@ -22,3 +22,4 @@ syn = "2.0.39"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trybuild = "1.0"
+musq = { path = "../musq" }

--- a/crates/musq-macros/src/core.rs
+++ b/crates/musq-macros/src/core.rs
@@ -96,6 +96,33 @@ pub struct RowField {
     pub skip: bool,
 }
 
+pub(crate) fn check_row_field_attrs(field: &RowField) -> syn::Result<()> {
+    if field.flatten {
+        if field.skip {
+            span_err!(&field.ty, "`flatten` cannot be combined with `skip`")?;
+        }
+        if field.try_from.is_some() {
+            span_err!(&field.ty, "`flatten` cannot be combined with `try_from`")?;
+        }
+        if !field.prefix.is_empty() {
+            span_err!(&field.ty, "`flatten` cannot be combined with `prefix`")?;
+        }
+        if field.rename.is_some() {
+            span_err!(&field.ty, "`flatten` cannot be combined with `rename`")?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn check_row_attrs(container: &RowContainer) -> syn::Result<()> {
+    if let ast::Data::Struct(fields) = &container.data {
+        for f in fields.iter() {
+            check_row_field_attrs(f)?;
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(musq))]
 pub struct TypeContainer {

--- a/crates/musq-macros/src/row.rs
+++ b/crates/musq-macros/src/row.rs
@@ -7,6 +7,7 @@ use super::core;
 
 pub fn expand_derive_from_row(input: &DeriveInput) -> syn::Result<TokenStream> {
     let container = core::RowContainer::from_derive_input(input)?;
+    core::check_row_attrs(&container)?;
     Ok(match &container.data {
         ast::Data::Struct(fields) => {
             // We know it's either a named struct or a tuple struct from darling restrictions.

--- a/crates/musq-macros/tests/trybuild/fail_row_flatten_skip.rs
+++ b/crates/musq-macros/tests/trybuild/fail_row_flatten_skip.rs
@@ -1,0 +1,14 @@
+use musq::FromRow;
+
+#[derive(FromRow)]
+struct Foo {
+    a: i32,
+}
+
+#[derive(FromRow)]
+struct Bad {
+    #[musq(flatten, skip)]
+    foo: Foo,
+}
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/fail_row_flatten_skip.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_row_flatten_skip.stderr
@@ -1,0 +1,5 @@
+error: `flatten` cannot be combined with `skip`
+  --> tests/trybuild/fail_row_flatten_skip.rs:11:10
+   |
+11 |     foo: Foo,
+   |          ^^^

--- a/crates/musq-macros/tests/trybuild/fail_row_flatten_try_from.rs
+++ b/crates/musq-macros/tests/trybuild/fail_row_flatten_try_from.rs
@@ -1,0 +1,14 @@
+use musq::FromRow;
+
+#[derive(FromRow)]
+struct Inner {
+    a: i32,
+}
+
+#[derive(FromRow)]
+struct Bad {
+    #[musq(flatten, try_from = "i32")]
+    inner: Inner,
+}
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/fail_row_flatten_try_from.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_row_flatten_try_from.stderr
@@ -1,0 +1,5 @@
+error: `flatten` cannot be combined with `try_from`
+  --> tests/trybuild/fail_row_flatten_try_from.rs:11:12
+   |
+11 |     inner: Inner,
+   |            ^^^^^


### PR DESCRIPTION
## Summary
- validate incompatible RowField attributes at parse time
- expose validation helpers
- test errors for `flatten` with `skip` or `try_from`
- restore `musq` as dev-dependency for macro tests

## Testing
- `cargo clippy --all --all-targets --all-features -- -D warnings`
- `cargo test --all --all-features`

------
https://chatgpt.com/codex/tasks/task_e_6880522377e083339aea275bc581341b