### PR TITLE
Tie prefix to flatten

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ struct User {
 }
 ```
 
-#### `#[musq(prefix = "prefix_")]`
+#### `#[musq(flatten, prefix = "prefix_")]`
 Adds a prefix to column names when using nested structures:
 
 ```rust
 #[derive(FromRow)]
 struct User {
     id: i32,
-    #[musq(prefix = "billing_")]
+    #[musq(flatten, prefix = "billing_")]
     billing_address: Address,  // Looks for "billing_street", "billing_city", etc.
-    #[musq(prefix = "shipping_")]
+    #[musq(flatten, prefix = "shipping_")]
     shipping_address: Address,
 }
 ```
@@ -137,7 +137,7 @@ struct ComplexUser {
     bio: Option<String>,
     #[musq(flatten)]
     address: Address,
-    #[musq(prefix = "work_")]
+    #[musq(flatten, prefix = "work_")]
     work_address: Address,
     #[musq(skip)]
     metadata: HashMap<String, String>,

--- a/crates/musq-macros/src/core.rs
+++ b/crates/musq-macros/src/core.rs
@@ -104,12 +104,11 @@ pub(crate) fn check_row_field_attrs(field: &RowField) -> syn::Result<()> {
         if field.try_from.is_some() {
             span_err!(&field.ty, "`flatten` cannot be combined with `try_from`")?;
         }
-        if !field.prefix.is_empty() {
-            span_err!(&field.ty, "`flatten` cannot be combined with `prefix`")?;
-        }
         if field.rename.is_some() {
             span_err!(&field.ty, "`flatten` cannot be combined with `rename`")?;
         }
+    } else if !field.prefix.is_empty() {
+        span_err!(&field.ty, "`prefix` requires `flatten`")?;
     }
     Ok(())
 }

--- a/crates/musq-macros/src/row.rs
+++ b/crates/musq-macros/src/row.rs
@@ -73,11 +73,12 @@ fn expand_struct(
 
             let expr: Expr = if field.flatten {
                 predicates.push(parse_quote!(#ty: musq::FromRow<#lifetime>));
-                parse_quote!(<#ty as musq::FromRow<#lifetime>>::from_row("", row))
-            } else if !field.prefix.is_empty() {
-                predicates.push(parse_quote!(#ty: musq::FromRow<#lifetime>));
-                let prefix = &field.prefix;
-                parse_quote!(<#ty as musq::FromRow<#lifetime>>::from_row(#prefix, row))
+                if field.prefix.is_empty() {
+                    parse_quote!(<#ty as musq::FromRow<#lifetime>>::from_row("", row))
+                } else {
+                    let prefix = &field.prefix;
+                    parse_quote!(<#ty as musq::FromRow<#lifetime>>::from_row(#prefix, row))
+                }
             } else if let Some(try_from) = &field.try_from {
                 predicates.push(parse_quote!(#try_from: musq::decode::Decode<#lifetime>));
                 parse_quote!(

--- a/crates/musq-macros/tests/trybuild/fail_row_prefix_without_flatten.rs
+++ b/crates/musq-macros/tests/trybuild/fail_row_prefix_without_flatten.rs
@@ -1,0 +1,14 @@
+use musq::FromRow;
+
+#[derive(FromRow)]
+struct Foo {
+    a: i32,
+}
+
+#[derive(FromRow)]
+struct Bad {
+    #[musq(prefix = "pre_")]
+    foo: Foo,
+}
+
+fn main() {}

--- a/crates/musq-macros/tests/trybuild/fail_row_prefix_without_flatten.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_row_prefix_without_flatten.stderr
@@ -1,0 +1,5 @@
+error: `prefix` requires `flatten`
+  --> tests/trybuild/fail_row_prefix_without_flatten.rs:11:10
+   |
+11 |     foo: Foo,
+   |          ^^^

--- a/crates/musq/tests/derives.rs
+++ b/crates/musq/tests/derives.rs
@@ -52,7 +52,7 @@ pub struct FromRowPlain {
     e: LowerCaseEnum,
     #[musq(flatten)]
     f: Flattened,
-    #[musq(prefix = "prefix_")]
+    #[musq(flatten, prefix = "prefix_")]
     g: Flattened,
 }
 


### PR DESCRIPTION
## Summary
- require `flatten` when using `prefix`
- adjust derives and README examples for new syntax
- add compile-fail test for prefix without flatten

## Testing
- `TRYBUILD=overwrite cargo test -p musq-macros`
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68805c2161b8833395f05dcd07ee85e1