### PR TITLE
Support optional flatten fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ struct User {
 }
 ```
 
+If the field type is wrapped in `Option`, it will be set to `None` when all
+columns of the nested struct are `NULL`:
+
+```rust
+#[derive(FromRow)]
+struct User {
+    id: i32,
+    name: String,
+    #[musq(flatten)]
+    address: Option<Address>,
+}
+```
+
+This also works together with the `prefix` attribute.
+
 #### `#[musq(flatten, prefix = "prefix_")]`
 Adds a prefix to column names when using nested structures:
 

--- a/crates/musq-macros/tests/trybuild/pass_option_flatten.rs
+++ b/crates/musq-macros/tests/trybuild/pass_option_flatten.rs
@@ -1,0 +1,16 @@
+use musq::FromRow;
+
+#[derive(FromRow)]
+struct Address {
+    street: String,
+    city: String,
+}
+
+#[derive(FromRow)]
+struct User {
+    id: i32,
+    #[musq(flatten)]
+    addr: Option<Address>,
+}
+
+fn main() {}

--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -27,7 +27,7 @@ pub mod types;
 pub use crate::{
     error::{DecodeError, EncodeError, Error, Result},
     executor::Execute,
-    from_row::FromRow,
+    from_row::{AllNull, FromRow},
     musq::{AutoVacuum, JournalMode, LockingMode, Musq, Synchronous},
     pool::{Pool, PoolConnection},
     query::{query, query_as, query_as_with, query_scalar, query_scalar_with, query_with},


### PR DESCRIPTION
## Summary
- implement `AllNull` trait for row checking
- support `Option` flatten fields in `FromRow` derive
- re-export `AllNull` and implement `FromRow` for `Option<T>` using it
- add tests for optional flattening and prefix handling
- document optional flatten behavior in README

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6880612ee5bc833386f3f81de9d3e93b