### PR TITLE
Implement sql! macros and builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@
 
 Musq is an async SQLite crate library for Rust.
 
+## SQL Macros
+
+Musq provides the `sql!` and `sql_as!` macros for ergonomic query construction.
+These macros use a familiar `format!` style syntax while binding parameters
+safely under the hood.
+
+```rust
+use musq::{sql, sql_as, FromRow};
+
+#[derive(FromRow)]
+struct User { id: i32, name: String }
+
+let id = 42;
+let user: User = sql_as!("SELECT id, name FROM users WHERE id = {id}")?
+    .fetch_one(&mut conn)
+    .await?;
+```
+
+
 # Rows
 
 ## #[derive(FromRow)]

--- a/crates/musq-macros/src/lib.rs
+++ b/crates/musq-macros/src/lib.rs
@@ -2,6 +2,7 @@ mod core;
 mod decode;
 mod encode;
 mod json;
+mod query_macros;
 mod row;
 
 #[proc_macro_derive(Json, attributes(musq))]
@@ -54,6 +55,16 @@ pub fn derive_from_row(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
         Ok(ts) => ts.into(),
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+#[proc_macro]
+pub fn sql(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    query_macros::expand_sql(input, false)
+}
+
+#[proc_macro]
+pub fn sql_as(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    query_macros::expand_sql(input, true)
 }
 
 #[cfg(test)]

--- a/crates/musq-macros/src/query_macros.rs
+++ b/crates/musq-macros/src/query_macros.rs
@@ -1,0 +1,197 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    Expr, Ident, LitStr, Result as SynResult, Token,
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+};
+
+enum MacroArg {
+    Pos(Expr),
+    Named(Ident, Expr),
+}
+
+impl Parse for MacroArg {
+    fn parse(input: ParseStream) -> SynResult<Self> {
+        if input.peek(Ident) && input.peek2(Token![=]) {
+            let ident: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+            let expr: Expr = input.parse()?;
+            Ok(MacroArg::Named(ident, expr))
+        } else {
+            let expr: Expr = input.parse()?;
+            Ok(MacroArg::Pos(expr))
+        }
+    }
+}
+
+struct MacroInput {
+    fmt: LitStr,
+    _comma: Option<Token![,]>,
+    args: syn::punctuated::Punctuated<MacroArg, Token![,]>,
+}
+
+impl Parse for MacroInput {
+    fn parse(input: ParseStream) -> SynResult<Self> {
+        let fmt: LitStr = input.parse()?;
+        let mut comma = None;
+        if input.peek(Token![,]) {
+            comma = Some(input.parse()?);
+        }
+        let args = syn::punctuated::Punctuated::parse_terminated(input)?;
+        Ok(MacroInput {
+            fmt,
+            _comma: comma,
+            args,
+        })
+    }
+}
+
+pub fn expand_sql(input: TokenStream, as_map: bool) -> TokenStream {
+    let MacroInput { fmt, args, .. } = parse_macro_input!(input as MacroInput);
+    let mut positionals: Vec<Expr> = Vec::new();
+    let mut named: std::collections::HashMap<String, Expr> = std::collections::HashMap::new();
+    for arg in args {
+        match arg {
+            MacroArg::Pos(expr) => positionals.push(expr),
+            MacroArg::Named(id, expr) => {
+                named.insert(id.to_string(), expr);
+            }
+        }
+    }
+    let fmt_string = fmt.value();
+    let segments = match parse_format_string(&fmt_string) {
+        Ok(v) => v,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let builder_ident = format_ident!("__builder");
+    let mut quoted = quote! {
+        let mut #builder_ident = musq::QueryBuilder::new();
+    };
+    let mut pos_i = 0usize;
+    for seg in segments {
+        match seg {
+            Segment::Lit(s) => {
+                quoted.extend(quote! { #builder_ident.push_sql(#s); });
+            }
+            Segment::Positional => {
+                if pos_i >= positionals.len() {
+                    return syn::Error::new_spanned(
+                        &fmt,
+                        "not enough arguments for positional placeholder",
+                    )
+                    .to_compile_error()
+                    .into();
+                }
+                let expr = &positionals[pos_i];
+                quoted.extend(quote! { #builder_ident.push_bind(#expr); });
+                pos_i += 1;
+            }
+            Segment::Named(name) => {
+                let expr = named
+                    .get(&name)
+                    .cloned()
+                    .unwrap_or_else(|| syn::parse_str::<Expr>(&name).unwrap());
+                let name_str = name;
+                quoted.extend(quote! { #builder_ident.push_bind_named(#name_str, #expr); });
+            }
+            Segment::Ident(expr) => {
+                quoted.extend(quote! { #builder_ident.push_identifier(#expr); });
+            }
+            Segment::Values(expr) => {
+                quoted.extend(quote! { #builder_ident.push_values(#expr); });
+            }
+            Segment::Idents(expr) => {
+                quoted.extend(quote! { #builder_ident.push_idents(#expr); });
+            }
+            Segment::Raw(expr) => {
+                quoted.extend(quote! { #builder_ident.push_raw(#expr); });
+            }
+        }
+    }
+    if pos_i < positionals.len() {
+        return syn::Error::new_spanned(&fmt, "too many positional arguments")
+            .to_compile_error()
+            .into();
+    }
+    let build_tokens = if as_map {
+        quote! { #builder_ident.build_map() }
+    } else {
+        quote! { #builder_ident.build() }
+    };
+    let output = quote!({
+        let query = { #quoted #build_tokens };
+        musq::Result::<_>::Ok(query)
+    });
+    output.into()
+}
+
+enum Segment {
+    Lit(String),
+    Positional,
+    Named(String),
+    Ident(Expr),
+    Values(Expr),
+    Idents(Expr),
+    Raw(Expr),
+}
+
+fn parse_format_string(s: &str) -> SynResult<Vec<Segment>> {
+    let mut chars = s.chars().peekable();
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    while let Some(c) = chars.next() {
+        if c == '{' {
+            if chars.peek() == Some(&'{') {
+                chars.next();
+                current.push('{');
+                continue;
+            }
+            if !current.is_empty() {
+                segments.push(Segment::Lit(current.clone()));
+                current.clear();
+            }
+            let mut inner = String::new();
+            for ch in &mut chars {
+                if ch == '}' {
+                    break;
+                }
+                inner.push(ch);
+            }
+            if inner.is_empty() {
+                segments.push(Segment::Positional);
+            } else if let Some(rest) = inner.strip_prefix("ident:") {
+                let expr: Expr = syn::parse_str(rest.trim()).unwrap();
+                segments.push(Segment::Ident(expr));
+            } else if let Some(rest) = inner.strip_prefix("values:") {
+                let expr: Expr = syn::parse_str(rest.trim()).unwrap();
+                segments.push(Segment::Values(expr));
+            } else if let Some(rest) = inner.strip_prefix("idents:") {
+                let expr: Expr = syn::parse_str(rest.trim()).unwrap();
+                segments.push(Segment::Idents(expr));
+            } else if let Some(rest) = inner.strip_prefix("raw:") {
+                let expr: Expr = syn::parse_str(rest.trim()).unwrap();
+                segments.push(Segment::Raw(expr));
+            } else {
+                let name = inner.trim().to_string();
+                segments.push(Segment::Named(name));
+            }
+        } else if c == '}' {
+            if chars.peek() == Some(&'}') {
+                chars.next();
+                current.push('}');
+            } else {
+                return Err(syn::Error::new_spanned(
+                    LitStr::new(s, proc_macro2::Span::call_site()),
+                    "unmatched `}`",
+                ));
+            }
+        } else {
+            current.push(c);
+        }
+    }
+    if !current.is_empty() {
+        segments.push(Segment::Lit(current));
+    }
+    Ok(segments)
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql.rs
@@ -1,0 +1,5 @@
+use musq_macros::sql;
+
+fn main() {
+    let _ = sql!("SELECT * FROM users WHERE id = {}", 1, 2);
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql.stderr
@@ -1,0 +1,5 @@
+error: too many positional arguments
+ --> tests/trybuild/fail_sql.rs:4:18
+  |
+4 |     let _ = sql!("SELECT * FROM users WHERE id = {}", 1, 2);
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/musq-macros/tests/trybuild/pass_sql.rs
+++ b/crates/musq-macros/tests/trybuild/pass_sql.rs
@@ -1,0 +1,6 @@
+use musq_macros::sql;
+
+fn main() {
+    let id = 1;
+    let _ = sql!("SELECT * FROM users WHERE id = {id}",);
+}

--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -17,6 +17,7 @@ mod logger;
 mod musq;
 mod pool;
 pub mod query;
+mod query_builder;
 mod query_result;
 mod row;
 mod statement_cache;
@@ -31,6 +32,7 @@ pub use crate::{
     musq::{AutoVacuum, JournalMode, LockingMode, Musq, Synchronous},
     pool::{Pool, PoolConnection},
     query::{query, query_as, query_as_with, query_scalar, query_scalar_with, query_with},
+    query_builder::QueryBuilder,
     query_result::QueryResult,
     row::Row,
     sqlite::{Arguments, Connection, Prepared, SqliteDataType, SqliteError, Value},

--- a/crates/musq/src/query.rs
+++ b/crates/musq/src/query.rs
@@ -12,6 +12,7 @@ use crate::{
 pub struct Query {
     pub(crate) statement: Either<String, Statement>,
     pub(crate) arguments: Option<Arguments>,
+    pub(crate) tainted: bool,
 }
 
 /// SQL query that will map its results to owned Rust types.
@@ -81,6 +82,16 @@ impl Query {
     pub fn bind_named<'q, T: 'q + Send + Encode>(self, name: &str, value: T) -> Self {
         self.try_bind_named(name, value)
             .expect("failed to bind named query parameter")
+    }
+
+    /// Returns true if the query contains raw SQL fragments.
+    pub fn is_tainted(&self) -> bool {
+        self.tainted
+    }
+
+    /// Convert this query into a [`QueryBuilder`] for further composition.
+    pub fn into_builder(self) -> crate::QueryBuilder {
+        crate::QueryBuilder::from_query(self)
     }
 }
 
@@ -312,6 +323,7 @@ pub(crate) fn query_statement(statement: &Statement) -> Query {
     Query {
         arguments: Some(Default::default()),
         statement: Either::Right(statement.clone()),
+        tainted: false,
     }
 }
 
@@ -320,6 +332,7 @@ pub(crate) fn query_statement_with(statement: &Statement, arguments: Arguments) 
     Query {
         arguments: Some(arguments),
         statement: Either::Right(statement.clone()),
+        tainted: false,
     }
 }
 
@@ -328,6 +341,7 @@ pub fn query(sql: &str) -> Query {
     Query {
         arguments: Some(Default::default()),
         statement: Either::Left(sql.to_string()),
+        tainted: false,
     }
 }
 
@@ -336,6 +350,7 @@ pub fn query_with(sql: &str, arguments: Arguments) -> Query {
     Query {
         arguments: Some(arguments),
         statement: Either::Left(sql.to_string()),
+        tainted: false,
     }
 }
 

--- a/crates/musq/src/query_builder.rs
+++ b/crates/musq/src/query_builder.rs
@@ -1,0 +1,121 @@
+use crate::{
+    Arguments, Result, Row,
+    encode::Encode,
+    executor::Execute,
+    query::{Map, Query, query_with},
+};
+
+/// Builder for constructing SQL queries programmatically.
+pub struct QueryBuilder {
+    sql: String,
+    args: Arguments,
+    tainted: bool,
+}
+
+impl Default for QueryBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QueryBuilder {
+    /// Create a new empty builder.
+    pub fn new() -> Self {
+        Self {
+            sql: String::new(),
+            args: Arguments::default(),
+            tainted: false,
+        }
+    }
+
+    /// Create a builder from an existing [`Query`].
+    pub fn from_query(mut query: Query) -> Self {
+        let sql = query.sql().to_string();
+        let args = query.take_arguments().unwrap_or_default();
+        let tainted = query.tainted;
+        Self { sql, args, tainted }
+    }
+
+    /// Push a raw SQL string fragment.
+    pub fn push_sql(&mut self, sql: &str) {
+        self.sql.push_str(sql);
+    }
+
+    /// Push a raw SQL fragment marking the builder as tainted.
+    pub fn push_raw(&mut self, raw: &str) {
+        self.tainted = true;
+        self.sql.push_str(raw);
+    }
+
+    /// Append an identifier quoted for SQLite.
+    pub fn push_identifier(&mut self, ident: &str) {
+        self.sql.push('"');
+        for c in ident.chars() {
+            if c == '"' {
+                self.sql.push('"');
+            }
+            self.sql.push(c);
+        }
+        self.sql.push('"');
+    }
+
+    /// Append a comma separated list of identifiers.
+    pub fn push_idents<I>(&mut self, idents: I)
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        let mut iter = idents.into_iter().peekable();
+        while let Some(ident) = iter.next() {
+            self.push_identifier(ident.as_ref());
+            if iter.peek().is_some() {
+                self.sql.push_str(", ");
+            }
+        }
+    }
+
+    /// Append a placeholder and bind a single value.
+    pub fn push_bind<T: Encode>(&mut self, value: T) {
+        self.sql.push('?');
+        let _ = self.args.add(value);
+    }
+
+    /// Append a named placeholder and bind a single value.
+    pub fn push_bind_named<T: Encode>(&mut self, name: &str, value: T) {
+        self.sql.push(':');
+        self.sql.push_str(name);
+        let _ = self.args.add_named(name, value);
+    }
+
+    /// Append a comma separated list of placeholders for multiple values.
+    pub fn push_values<I, T>(&mut self, values: I)
+    where
+        I: IntoIterator<Item = T>,
+        T: Encode,
+    {
+        let mut iter = values.into_iter().peekable();
+        while let Some(v) = iter.next() {
+            self.push_bind(v);
+            if iter.peek().is_some() {
+                self.sql.push_str(", ");
+            }
+        }
+    }
+
+    /// Build the final [`Query`].
+    pub fn build(self) -> Query {
+        let mut q = query_with(&self.sql, self.args);
+        q.tainted = self.tainted;
+        q
+    }
+
+    /// Build a mapped query returning type `O`.
+    pub fn build_map<O>(self) -> Map<impl FnMut(Row) -> Result<O> + Send>
+    where
+        O: Send + Unpin + for<'r> crate::from_row::FromRow<'r>,
+    {
+        let mut q = query_with(&self.sql, self.args);
+        q.tainted = self.tainted;
+        q.try_map(|row| O::from_row("", &row))
+    }
+}

--- a/crates/musq/tests/sql_macro.rs
+++ b/crates/musq/tests/sql_macro.rs
@@ -1,0 +1,32 @@
+use musq::{FromRow, sql, sql_as};
+use musq_test::tdb;
+
+#[derive(Debug, PartialEq, FromRow)]
+struct User {
+    id: i32,
+    name: String,
+}
+
+#[tokio::test]
+async fn basic_sql_macro() -> anyhow::Result<()> {
+    let mut conn = tdb().await?;
+    musq::query("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+        .execute(&mut conn)
+        .await?;
+    musq::query("INSERT INTO users (id, name) VALUES (1, 'Alice')")
+        .execute(&mut conn)
+        .await?;
+
+    let id = 1;
+    let user: User = sql_as!("SELECT id, name FROM users WHERE id = {id}")?
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(user.id, 1);
+    assert_eq!(user.name, "Alice");
+
+    let q = sql!("SELECT * FROM users WHERE id = {}", 1)?;
+    let row = q.fetch_one(&mut conn).await?;
+    let name: String = row.get_value_idx(1)?;
+    assert_eq!(name, "Alice");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add new `sql!` and `sql_as!` procedural macros
- implement `QueryBuilder` with raw SQL support
- expose builder through `Query::into_builder`
- support tainted queries
- document SQL macros
- add compile time and runtime tests

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`
- `cargo test --test sql_macro -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6880a4f8a41c83338b8881bf1bbfb147