### PR TITLE
Implement sql! macro and tests

### DIFF
--- a/crates/musq-macros/src/lib.rs
+++ b/crates/musq-macros/src/lib.rs
@@ -3,6 +3,7 @@ mod decode;
 mod encode;
 mod json;
 mod row;
+mod sql;
 
 #[proc_macro_derive(Json, attributes(musq))]
 pub fn derive_json(tokenstream: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -58,3 +59,13 @@ pub fn derive_from_row(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 
 #[cfg(test)]
 mod tests;
+
+#[proc_macro]
+pub fn sql(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    sql::sql(item)
+}
+
+#[proc_macro]
+pub fn sql_as(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    sql::sql_as(item)
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql.rs
@@ -1,0 +1,6 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let _ = sql!("SELECT {}", )?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql.stderr
@@ -1,0 +1,7 @@
+error: missing positional argument
+ --> tests/trybuild/fail_sql.rs:4:13
+  |
+4 |     let _ = sql!("SELECT {}", )?;
+  |             ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `sql` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/fail_sql_empty_idents.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql_empty_idents.rs
@@ -1,0 +1,6 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let _ = sql!("SELECT {idents:[]} FROM t")?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql_empty_idents.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql_empty_idents.stderr
@@ -1,0 +1,7 @@
+error: empty list
+ --> tests/trybuild/fail_sql_empty_idents.rs:4:13
+  |
+4 |     let _ = sql!("SELECT {idents:[]} FROM t")?;
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `sql` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/fail_sql_empty_values.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql_empty_values.rs
@@ -1,0 +1,6 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let _ = sql!("SELECT * FROM t WHERE id IN ({values:[]})")?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql_empty_values.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql_empty_values.stderr
@@ -1,0 +1,7 @@
+error: empty list
+ --> tests/trybuild/fail_sql_empty_values.rs:4:13
+  |
+4 |     let _ = sql!("SELECT * FROM t WHERE id IN ({values:[]})")?;
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `sql` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/fail_sql_malformed.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql_malformed.rs
@@ -1,0 +1,6 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let _ = sql!("SELECT {ident}")?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql_malformed.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql_malformed.stderr
@@ -1,0 +1,7 @@
+error: malformed placeholder
+ --> tests/trybuild/fail_sql_malformed.rs:4:13
+  |
+4 |     let _ = sql!("SELECT {ident}")?;
+  |             ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `sql` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/fail_sql_malformed2.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql_malformed2.rs
@@ -1,0 +1,6 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let _ = sql!("SELECT {raw}")?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql_malformed2.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql_malformed2.stderr
@@ -1,0 +1,7 @@
+error: malformed placeholder
+ --> tests/trybuild/fail_sql_malformed2.rs:4:13
+  |
+4 |     let _ = sql!("SELECT {raw}")?;
+  |             ^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `sql` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/fail_sql_missing_named.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql_missing_named.rs
@@ -1,0 +1,6 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let _ = sql!("SELECT {id}")?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql_missing_named.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql_missing_named.stderr
@@ -1,0 +1,11 @@
+error[E0425]: cannot find value `id` in this scope
+ --> tests/trybuild/fail_sql_missing_named.rs:4:13
+  |
+4 |     let _ = sql!("SELECT {id}")?;
+  |             ^^^^^^^^^^^^^^^^^^^ not found in this scope
+  |
+  = note: this error originates in the macro `sql` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this function
+  |
+1 + use std::process::id;
+  |

--- a/crates/musq-macros/tests/trybuild/fail_sql_too_many.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql_too_many.rs
@@ -1,0 +1,6 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let _ = sql!("SELECT {}", 1, 2)?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql_too_many.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql_too_many.stderr
@@ -1,0 +1,7 @@
+error: unused positional arguments
+ --> tests/trybuild/fail_sql_too_many.rs:4:13
+  |
+4 |     let _ = sql!("SELECT {}", 1, 2)?;
+  |             ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `sql` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/fail_sql_unclosed.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql_unclosed.rs
@@ -1,0 +1,6 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let _ = sql!("SELECT {id")?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql_unclosed.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql_unclosed.stderr
@@ -1,0 +1,7 @@
+error: unmatched `{`
+ --> tests/trybuild/fail_sql_unclosed.rs:4:13
+  |
+4 |     let _ = sql!("SELECT {id")?;
+  |             ^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `sql` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/fail_sql_unused_named.rs
+++ b/crates/musq-macros/tests/trybuild/fail_sql_unused_named.rs
@@ -1,0 +1,6 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let _ = sql!("SELECT 1", id = 5)?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/fail_sql_unused_named.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_sql_unused_named.stderr
@@ -1,0 +1,7 @@
+error: unused named arguments
+ --> tests/trybuild/fail_sql_unused_named.rs:4:13
+  |
+4 |     let _ = sql!("SELECT 1", id = 5)?;
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `sql` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/musq-macros/tests/trybuild/pass_sql.rs
+++ b/crates/musq-macros/tests/trybuild/pass_sql.rs
@@ -1,0 +1,7 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let id = 5;
+    let _ = sql!("SELECT {}", id)?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/pass_sql_ident.rs
+++ b/crates/musq-macros/tests/trybuild/pass_sql_ident.rs
@@ -1,0 +1,7 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let table = "foo";
+    let _ = sql!("SELECT * FROM {ident:table}")?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/pass_sql_list.rs
+++ b/crates/musq-macros/tests/trybuild/pass_sql_list.rs
@@ -1,0 +1,8 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let ids = vec![1,2];
+    let cols = ["id", "name"];
+    let _ = sql!("SELECT {idents:cols} FROM t WHERE id IN ({values:ids})")?;
+    Ok(())
+}

--- a/crates/musq-macros/tests/trybuild/pass_sql_named.rs
+++ b/crates/musq-macros/tests/trybuild/pass_sql_named.rs
@@ -1,0 +1,7 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let id = 1;
+    let _ = sql!("SELECT {id}")?;
+    Ok(())
+}

--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -17,6 +17,7 @@ mod logger;
 mod musq;
 mod pool;
 pub mod query;
+mod query_builder;
 mod query_result;
 mod row;
 mod statement_cache;
@@ -30,7 +31,9 @@ pub use crate::{
     from_row::{AllNull, FromRow},
     musq::{AutoVacuum, JournalMode, LockingMode, Musq, Synchronous},
     pool::{Pool, PoolConnection},
+    query::quote_identifier,
     query::{query, query_as, query_as_with, query_scalar, query_scalar_with, query_with},
+    query_builder::QueryBuilder,
     query_result::QueryResult,
     row::Row,
     sqlite::{Arguments, Connection, Prepared, SqliteDataType, SqliteError, Value},

--- a/crates/musq/src/query_builder.rs
+++ b/crates/musq/src/query_builder.rs
@@ -1,0 +1,92 @@
+use crate::{Arguments, Result, encode::Encode, query::Query};
+use either::Either;
+
+#[derive(Default)]
+pub struct QueryBuilder {
+    pub(crate) sql: String,
+    pub(crate) arguments: Arguments,
+    pub(crate) tainted: bool,
+}
+
+impl QueryBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn from_parts(sql: String, arguments: Arguments, tainted: bool) -> Self {
+        Self {
+            sql,
+            arguments,
+            tainted,
+        }
+    }
+
+    pub fn push_sql(&mut self, sql: &str) {
+        self.sql.push_str(sql);
+    }
+
+    pub fn push_raw(&mut self, raw: &str) {
+        self.sql.push_str(raw);
+        self.tainted = true;
+    }
+
+    pub fn push_bind<T: Encode>(&mut self, value: T) -> Result<()> {
+        self.arguments.add(value)?;
+        self.sql.push('?');
+        Ok(())
+    }
+
+    pub fn push_bind_named<T: Encode>(&mut self, name: &str, value: T) -> Result<()> {
+        self.arguments.add_named(name, value)?;
+        self.sql.push(':');
+        self.sql.push_str(name);
+        Ok(())
+    }
+
+    pub fn push_values<I, T>(&mut self, iter: I) -> Result<()>
+    where
+        I: IntoIterator<Item = T>,
+        T: Encode,
+    {
+        let mut first = true;
+        for v in iter {
+            if !first {
+                self.sql.push_str(", ");
+            }
+            first = false;
+            self.sql.push('?');
+            self.arguments.add(v)?;
+        }
+        if first {
+            return Err(crate::Error::Protocol("empty values".into()));
+        }
+        Ok(())
+    }
+
+    pub fn push_idents<I>(&mut self, iter: I) -> Result<()>
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        let mut first = true;
+        for ident in iter {
+            if !first {
+                self.sql.push_str(", ");
+            }
+            first = false;
+            self.sql.push_str(&crate::quote_identifier(ident.as_ref()));
+        }
+        if first {
+            return Err(crate::Error::Protocol("empty idents".into()));
+        }
+        Ok(())
+    }
+
+    pub fn build(self) -> Query {
+        Query {
+            statement: Either::Left(self.sql),
+            arguments: Some(self.arguments),
+            tainted: self.tainted,
+        }
+    }
+}

--- a/crates/musq/tests/sql_macros.rs
+++ b/crates/musq/tests/sql_macros.rs
@@ -1,0 +1,158 @@
+use musq::types::time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
+use musq::*;
+use musq_test::connection;
+use time::macros::{date, datetime, time};
+
+#[derive(FromRow, Debug, PartialEq)]
+struct User {
+    id: i32,
+    name: String,
+    status: String,
+}
+
+macro_rules! bind_check {
+    ($name:ident: $ty:ty = $value:expr) => {
+        #[tokio::test]
+        async fn $name() -> anyhow::Result<()> {
+            let mut conn = connection().await?;
+            let val: $ty = $value;
+
+            let row = sql!("SELECT {}", val.clone())?.fetch_one(&mut conn).await?;
+            let out: $ty = row.get_value_idx(0)?;
+            assert_eq!(out, val);
+
+            let row = sql!("SELECT {v}", v = val.clone())?
+                .fetch_one(&mut conn)
+                .await?;
+            let out: $ty = row.get_value_idx(0)?;
+            assert_eq!(out, val);
+
+            let list = vec![val.clone(), val.clone()];
+            let row = sql!("SELECT {values:list}")?.fetch_one(&mut conn).await?;
+            let out0: $ty = row.get_value_idx(0)?;
+            let out1: $ty = row.get_value_idx(1)?;
+            assert_eq!(out0, val);
+            assert_eq!(out1, val);
+            Ok(())
+        }
+    };
+}
+
+#[tokio::test]
+async fn test_placeholders() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    sql!("CREATE TABLE users (id INTEGER, name TEXT, status TEXT)")?
+        .execute(&mut conn)
+        .await?;
+
+    let id = 1;
+    let name = "Alice";
+    // positional and named
+    let insert = sql!(
+        "INSERT INTO users (id, name, status) VALUES ({}, {}, 'active')",
+        id,
+        name
+    )?;
+    println!("insert sql: {}", insert.sql());
+    insert.execute(&mut conn).await?;
+
+    let row = sql!("SELECT name FROM users WHERE id = {id}")?
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(row.get_value_idx::<String>(0)?, "Alice");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_ident_and_lists() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    let table = "user-data";
+    sql!("CREATE TABLE {ident:table} (id INTEGER, name TEXT)")?
+        .execute(&mut conn)
+        .await?;
+    sql!("INSERT INTO {ident:table} (id, name) VALUES (1, 'a'), (2, 'b')")?
+        .execute(&mut conn)
+        .await?;
+    let ids = [1, 2];
+    let cols = ["id", "name"];
+    let rows = sql!("SELECT {idents:cols} FROM {ident:table} WHERE id IN ({values:ids})")?
+        .fetch_all(&mut conn)
+        .await?;
+    assert_eq!(rows.len(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_raw_and_taint() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    sql!("CREATE TABLE t (id INTEGER)")?
+        .execute(&mut conn)
+        .await?;
+    sql!("INSERT INTO t (id) VALUES (1), (2)")?
+        .execute(&mut conn)
+        .await?;
+    let q = sql!("SELECT * FROM t {raw:\"ORDER BY id DESC\"}")?;
+    assert!(q.is_tainted());
+    let rows = q.fetch_all(&mut conn).await?;
+    assert_eq!(rows.len(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sql_as_and_builder() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    sql!("CREATE TABLE users (id INTEGER, name TEXT, status TEXT)")?
+        .execute(&mut conn)
+        .await?;
+    sql!("INSERT INTO users (id, name, status) VALUES (1, 'Alice', 'active')")?
+        .execute(&mut conn)
+        .await?;
+    let user: User = sql_as!("SELECT id, name, status FROM users WHERE id = {id}", id = 1)?
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(
+        user,
+        User {
+            id: 1,
+            name: "Alice".into(),
+            status: "active".into()
+        }
+    );
+    let tuple: (i32, String) = sql_as!("SELECT id, name FROM users WHERE id = {id}", id = 1)?
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(tuple, (1, "Alice".into()));
+
+    let base = sql!(
+        "SELECT id FROM users WHERE status = {status}",
+        status = "active"
+    )?;
+    let final_q = {
+        let mut b = base.into_builder();
+        b.push_sql(" ORDER BY id");
+        b.build()
+    };
+    let ids: Vec<i32> = final_q
+        .try_map(|row| row.get_value_idx::<i32>(0))
+        .fetch_all(&mut conn)
+        .await?;
+    assert_eq!(ids, vec![1]);
+    Ok(())
+}
+
+bind_check!(bind_bool: bool = true);
+bind_check!(bind_i8: i8 = -5);
+bind_check!(bind_i16: i16 = -1234);
+bind_check!(bind_i32: i32 = 42);
+bind_check!(bind_i64: i64 = 9001);
+bind_check!(bind_u8: u8 = 5);
+bind_check!(bind_u16: u16 = 55);
+bind_check!(bind_u32: u32 = 999);
+bind_check!(bind_f32: f32 = std::f32::consts::PI);
+bind_check!(bind_f64: f64 = std::f64::consts::E);
+bind_check!(bind_string: String = "hello".to_string());
+bind_check!(bind_bytes: Vec<u8> = vec![1u8, 2, 3]);
+bind_check!(bind_offset_datetime: OffsetDateTime = datetime!(2025 - 7 - 22 6:20:47 UTC));
+bind_check!(bind_primitive_datetime: PrimitiveDateTime = datetime!(2025 - 1 - 15 12:30:45));
+bind_check!(bind_date: Date = date!(2025 - 1 - 1));
+bind_check!(bind_time: Time = time!(23:59:59));


### PR DESCRIPTION
## Summary
- finalize `sql!` and `sql_as!` implementation
- add public `QueryBuilder` API and taint tracking
- document usage of the macros with examples
- add extensive compile-time tests for macro errors
- add runtime tests exercising all placeholder types
- add broad type coverage tests for sql! macro

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6880a4f8a41c83338b8881bf1bbfb147