### PR TITLE
Add InsertInto query builder

### DIFF
--- a/crates/musq/src/insert_builder.rs
+++ b/crates/musq/src/insert_builder.rs
@@ -1,0 +1,60 @@
+use crate::query::Query;
+use crate::{
+    Arguments, Connection, Pool, QueryResult, Result, encode::Encode, query::query_with,
+    quote_identifier,
+};
+
+/// Builder for constructing `INSERT INTO` queries.
+pub struct InsertInto {
+    table: String,
+    columns: Vec<String>,
+    arguments: Arguments,
+}
+
+/// Create a new [`InsertInto`] builder for the given table.
+#[allow(non_snake_case)]
+pub fn InsertInto(table: &str) -> InsertInto {
+    InsertInto {
+        table: quote_identifier(table),
+        columns: Vec::new(),
+        arguments: Arguments::default(),
+    }
+}
+
+impl InsertInto {
+    /// Add a column/value pair to the `INSERT` statement.
+    pub fn value<T: Encode>(mut self, column: &str, value: T) -> Self {
+        self.columns.push(quote_identifier(column));
+        let _ = self.arguments.add(value);
+        self
+    }
+
+    /// Build the final [`Query`].
+    pub fn query(self) -> Result<Query> {
+        if self.columns.is_empty() {
+            return Err(crate::Error::Protocol("Insert query has no values".into()));
+        }
+        let columns = self.columns.join(", ");
+        let placeholders = (0..self.columns.len())
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "INSERT INTO {} ({}) VALUES ({})",
+            self.table, columns, placeholders
+        );
+        Ok(query_with(&sql, self.arguments))
+    }
+
+    /// Build and execute the query using a [`Connection`].
+    pub async fn execute(self, conn: &mut Connection) -> Result<QueryResult> {
+        let q = self.query()?;
+        conn.execute(q).await
+    }
+
+    /// Build and execute the query using a [`Pool`].
+    pub async fn execute_on_pool(self, pool: &Pool) -> Result<QueryResult> {
+        let q = self.query()?;
+        pool.execute(q).await
+    }
+}

--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -14,6 +14,7 @@ mod executor;
 mod from_row;
 #[macro_use]
 mod logger;
+mod insert_builder;
 mod musq;
 mod pool;
 pub mod query;
@@ -29,6 +30,7 @@ pub use crate::{
     error::{DecodeError, EncodeError, Error, Result},
     executor::Execute,
     from_row::{AllNull, FromRow},
+    insert_builder::InsertInto,
     musq::{AutoVacuum, JournalMode, LockingMode, Musq, Synchronous},
     pool::{Pool, PoolConnection},
     query::quote_identifier,

--- a/crates/musq/tests/insert_builder.rs
+++ b/crates/musq/tests/insert_builder.rs
@@ -1,0 +1,104 @@
+use musq::{Execute, InsertInto, query_scalar};
+use musq_test::connection;
+
+#[tokio::test]
+async fn no_values_query() -> anyhow::Result<()> {
+    let builder = InsertInto("users");
+    assert!(builder.query().is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn no_values_execute() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    conn.execute("CREATE TABLE users (id INTEGER)").await?;
+    let res = InsertInto("users").execute(&mut conn).await;
+    assert!(res.is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn single_value_insert() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    conn.execute("CREATE TABLE t (id INTEGER)").await?;
+    let query = InsertInto("t").value("id", 5).query()?;
+    assert_eq!(query.sql(), "INSERT INTO \"t\" (\"id\") VALUES (?)");
+    InsertInto("t").value("id", 5).execute(&mut conn).await?;
+    let id: i32 = query_scalar("SELECT id FROM t")
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(id, 5);
+    Ok(())
+}
+
+#[tokio::test]
+async fn multiple_values_insert() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    conn.execute("CREATE TABLE stuff (a INTEGER, b TEXT, c BOOLEAN, d BLOB)")
+        .await?;
+    InsertInto("stuff")
+        .value("a", 1_i32)
+        .value("b", "hi")
+        .value("c", true)
+        .value("d", vec![1u8, 2, 3])
+        .execute(&mut conn)
+        .await?;
+    let row: (i32, String, bool, Vec<u8>) = musq::query_as("SELECT a, b, c, d FROM stuff")
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(row.0, 1);
+    assert_eq!(row.1, "hi");
+    assert!(row.2);
+    assert_eq!(row.3, vec![1u8, 2, 3]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn quoted_identifiers() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    conn.execute("CREATE TABLE \"user-data\" (\"from-column\" INTEGER)")
+        .await?;
+    let q = InsertInto("user-data").value("from-column", 10).query()?;
+    assert_eq!(
+        q.sql(),
+        "INSERT INTO \"user-data\" (\"from-column\") VALUES (?)"
+    );
+    q.execute(&mut conn).await?;
+    let val: i32 = query_scalar("SELECT \"from-column\" FROM \"user-data\"")
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(val, 10);
+    Ok(())
+}
+
+#[tokio::test]
+async fn execute_on_pool() -> anyhow::Result<()> {
+    let pool = musq::Musq::new().open_in_memory().await?;
+    pool.execute(musq::query("CREATE TABLE pool_t (id INTEGER)"))
+        .await?;
+    InsertInto("pool_t")
+        .value("id", 1)
+        .execute_on_pool(&pool)
+        .await?;
+    let mut conn = pool.acquire().await?;
+    let id: i32 = query_scalar("SELECT id FROM pool_t")
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(id, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn transaction_insert() -> anyhow::Result<()> {
+    let mut conn = connection().await?;
+    conn.execute("CREATE TABLE tx_t (id INTEGER)").await?;
+    let mut tx = conn.begin().await?;
+    InsertInto("tx_t").value("id", 7).execute(&mut tx).await?;
+    tx.commit().await?;
+    drop(tx);
+    let id: i32 = query_scalar("SELECT id FROM tx_t")
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(id, 7);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- introduce `InsertInto` builder for constructing `INSERT` statements
- export the builder from the crate
- test `InsertInto` for various cases

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6880ca28a6188333a1fae80d9805d4dc