### PR TITLE
Add query join facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,24 @@ let final_query = {
 };
 ```
 
+### Dynamic query composition
+
+`Query` objects can be combined using [`Query::join`], which appends the SQL and
+parameters from one query to another. This is handy for building queries from
+optional fragments.
+
+```rust
+let mut query = sql!("SELECT * FROM products WHERE 1 = 1")?;
+
+if let Some(category) = &params.category {
+    query = query.join(sql!("AND category = {}", category)?);
+}
+
+if let Some(min_price) = params.min_price {
+    query = query.join(sql!("AND price >= {}", min_price)?);
+}
+```
+
 # Development
 
 

--- a/crates/musq/src/query.rs
+++ b/crates/musq/src/query.rs
@@ -110,7 +110,6 @@ impl QueryExecutor for &crate::Connection {
     }
 }
 
-
 // Implement QueryExecutor for &PoolConnection
 #[async_trait]
 impl QueryExecutor for &crate::pool::PoolConnection {
@@ -244,6 +243,16 @@ impl Query {
             self.arguments.unwrap_or_default(),
             self.tainted,
         )
+    }
+
+    /// Joins this query with another [`Query`].
+    ///
+    /// The SQL and arguments from `other` are appended to this query and a new
+    /// combined query is returned.
+    pub fn join(self, other: Query) -> Query {
+        let mut builder = self.into_builder();
+        builder.push_query(other);
+        builder.build()
     }
 
     /// Attempt to bind a value for use with this SQL query.

--- a/crates/musq/tests/query_join.rs
+++ b/crates/musq/tests/query_join.rs
@@ -1,0 +1,103 @@
+use musq::query::Query;
+use musq::{Execute, sql};
+use musq_test::connection;
+
+// Helper to extract i32 from first column
+async fn fetch_vals(q: Query) -> anyhow::Result<Vec<i32>> {
+    let conn = connection().await?;
+    Ok(q.try_map(|row| row.get_value_idx::<i32>(0))
+        .fetch_all(&conn)
+        .await?)
+}
+
+#[tokio::test]
+async fn join_positional() -> anyhow::Result<()> {
+    let q1 = sql!("SELECT {}", 1)?;
+    let q2 = sql!("UNION SELECT {}", 2)?;
+    let q = q1.join(q2);
+    assert_eq!(q.sql(), "SELECT ? UNION SELECT ?");
+    let vals = fetch_vals(q).await?;
+    assert_eq!(vals, vec![1, 2]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn join_named() -> anyhow::Result<()> {
+    let q1 = sql!("SELECT {a}", a = 3)?;
+    let q2 = sql!("UNION SELECT {b}", b = 4)?;
+    let q = q1.join(q2);
+    assert_eq!(q.sql(), "SELECT :a UNION SELECT :b");
+    let vals = fetch_vals(q).await?;
+    assert_eq!(vals, vec![3, 4]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn join_mixed_args() -> anyhow::Result<()> {
+    let q1 = sql!("SELECT {a}", a = 5)?;
+    let q2 = sql!("UNION SELECT {}", 6)?;
+    let q = q1.join(q2);
+    assert_eq!(q.sql(), "SELECT :a UNION SELECT ?");
+    let vals = fetch_vals(q).await?;
+    assert_eq!(vals, vec![5, 6]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn join_limit_clause() -> anyhow::Result<()> {
+    let base = sql!("SELECT value FROM (SELECT 1 AS value UNION ALL SELECT 2 UNION ALL SELECT 3)")?;
+    let limit = sql!("LIMIT {}", 2)?;
+    let q = base.join(limit);
+    assert_eq!(
+        q.sql(),
+        "SELECT value FROM (SELECT 1 AS value UNION ALL SELECT 2 UNION ALL SELECT 3) LIMIT ?"
+    );
+    let vals = fetch_vals(q).await?;
+    assert_eq!(vals, vec![1, 2]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn join_dynamic_where() -> anyhow::Result<()> {
+    let mut q = sql!(
+        "SELECT value FROM (SELECT 1 AS value UNION ALL SELECT 2 UNION ALL SELECT 3) WHERE 1 = 1"
+    )?;
+    let add = Some(2);
+    if let Some(v) = add {
+        q = q.join(sql!("AND value >= {}", v)?);
+    }
+    let vals = fetch_vals(q).await?;
+    assert_eq!(vals, vec![2, 3]);
+    Ok(())
+}
+
+fn order_by_desc() -> Query {
+    sql!("ORDER BY value DESC").unwrap()
+}
+
+#[tokio::test]
+async fn join_reusable_fragment() -> anyhow::Result<()> {
+    let q = sql!("SELECT value FROM (SELECT 1 AS value UNION ALL SELECT 2 UNION ALL SELECT 3)")?
+        .join(order_by_desc());
+    assert_eq!(
+        q.sql(),
+        "SELECT value FROM (SELECT 1 AS value UNION ALL SELECT 2 UNION ALL SELECT 3) ORDER BY value DESC"
+    );
+    let vals = fetch_vals(q).await?;
+    assert_eq!(vals, vec![3, 2, 1]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn join_cte() -> anyhow::Result<()> {
+    let with = sql!("WITH nums(x) AS (VALUES (1),(2))")?;
+    let select = sql!("SELECT x FROM nums")?;
+    let q = with.join(select);
+    assert_eq!(
+        q.sql(),
+        "WITH nums(x) AS (VALUES (1),(2)) SELECT x FROM nums"
+    );
+    let vals = fetch_vals(q).await?;
+    assert_eq!(vals, vec![1, 2]);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement `QueryBuilder::push_query`
- implement `Query::join`
- add tests for combining queries
- document dynamic query composition in README

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`
- `cargo test --test query_join --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6881b9c2c5408333825cd6d3510f23ed