### PR TITLE
Add identifier quoting test

### DIFF
--- a/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
@@ -35,9 +35,6 @@ help: the type constructed contains `fn(&_) -> Bad<'_, _> {Bad::<'_, _>::A}` due
   | |_____- this argument influences the type of `Ok`
 note: tuple variant defined here
  --> $RUST/core/src/result.rs
-  |
-  |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
-  |     ^^
   = note: this error originates in the derive macro `Codec` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use parentheses to construct this tuple variant
   |

--- a/crates/musq/tests/quote_identifier.rs
+++ b/crates/musq/tests/quote_identifier.rs
@@ -1,0 +1,27 @@
+use musq::{query, query_scalar, quote_identifier};
+use musq_test::connection;
+
+#[tokio::test]
+async fn quote_identifier_escapes_double_quotes() -> anyhow::Result<()> {
+    assert_eq!(quote_identifier("user\"name"), "\"user\"\"name\"");
+
+    let conn = connection().await?;
+    let ident = "user\"name";
+    query(&format!(
+        "CREATE TABLE {} (id INTEGER)",
+        quote_identifier(ident)
+    ))
+    .execute(&conn)
+    .await?;
+    query(&format!(
+        "INSERT INTO {} (id) VALUES (1)",
+        quote_identifier(ident)
+    ))
+    .execute(&conn)
+    .await?;
+    let val: i32 = query_scalar(&format!("SELECT id FROM {}", quote_identifier(ident)))
+        .fetch_one(&conn)
+        .await?;
+    assert_eq!(val, 1);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a test for quoting identifiers containing `"`
- update trybuild stderr expectation

## Testing
- `cargo clippy --fix --allow-dirty --tests --examples --benches`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6882052a9c688333bba65bb55c3f954f