### PR TITLE
Add QueryLogger log capture tests

### DIFF
--- a/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
@@ -35,9 +35,6 @@ help: the type constructed contains `fn(&_) -> Bad<'_, _> {Bad::<'_, _>::A}` due
   | |_____- this argument influences the type of `Ok`
 note: tuple variant defined here
  --> $RUST/core/src/result.rs
-  |
-  |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
-  |     ^^
   = note: this error originates in the derive macro `Codec` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use parentheses to construct this tuple variant
   |

--- a/crates/musq/tests/logger.rs
+++ b/crates/musq/tests/logger.rs
@@ -1,0 +1,116 @@
+#![allow(dead_code)]
+#[path = "../src/logger.rs"]
+mod logger;
+
+use log::LevelFilter;
+use logger::{LogSettings, QueryLogger};
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::{Event, Level, Metadata, Subscriber, dispatcher};
+
+#[derive(Clone, Default)]
+struct CapturingSubscriber {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+#[derive(Clone, Debug)]
+struct CapturedEvent {
+    level: Level,
+    fields: HashMap<String, String>,
+}
+
+impl CapturingSubscriber {
+    fn events(&self) -> Vec<CapturedEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+struct FieldVisitor<'a> {
+    fields: &'a mut HashMap<String, String>,
+}
+
+impl<'a> Visit for FieldVisitor<'a> {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.fields
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+}
+
+impl Subscriber for CapturingSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _attrs: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut fields = HashMap::new();
+        let mut visitor = FieldVisitor {
+            fields: &mut fields,
+        };
+        event.record(&mut visitor);
+        self.events.lock().unwrap().push(CapturedEvent {
+            level: *event.metadata().level(),
+            fields,
+        });
+    }
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+#[test]
+fn logs_at_statements_level() {
+    let subscriber = CapturingSubscriber::default();
+    let dispatch = dispatcher::Dispatch::new(subscriber.clone());
+    let _guard = dispatcher::set_default(&dispatch);
+
+    let mut settings = LogSettings::default();
+    settings.log_statements(LevelFilter::Info);
+    settings.log_slow_statements(LevelFilter::Warn, std::time::Duration::from_secs(60));
+
+    let mut logger = QueryLogger::new("SELECT 1", settings);
+    logger.increment_rows_returned();
+    logger.increase_rows_affected(2);
+    drop(logger);
+    drop(_guard);
+
+    let events = subscriber.events();
+    assert_eq!(events.len(), 1);
+    let event = &events[0];
+    assert_eq!(event.level, Level::INFO);
+    assert_eq!(event.fields.get("rows_returned").unwrap(), "1");
+    assert_eq!(event.fields.get("rows_affected").unwrap(), "2");
+}
+
+#[test]
+fn logs_at_slow_level() {
+    let subscriber = CapturingSubscriber::default();
+    let dispatch = dispatcher::Dispatch::new(subscriber.clone());
+    let _guard = dispatcher::set_default(&dispatch);
+
+    let mut settings = LogSettings::default();
+    settings.log_statements(LevelFilter::Info);
+    settings.log_slow_statements(LevelFilter::Warn, std::time::Duration::from_millis(0));
+
+    let mut logger = QueryLogger::new("UPDATE foo", settings);
+    logger.increase_rows_affected(5);
+    drop(logger);
+    drop(_guard);
+
+    let events = subscriber.events();
+    assert_eq!(events.len(), 1);
+    let event = &events[0];
+    assert_eq!(event.level, Level::WARN);
+    assert_eq!(event.fields.get("rows_affected").unwrap(), "5");
+}


### PR DESCRIPTION
## Summary
- test QueryLogger log levels and stats
- update trybuild stderr for fail_codec_enum

## Testing
- `cargo clippy --fix --allow-dirty --tests --examples --benches`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688208f8db788333b25d7c5c3b0127f2