### PR TITLE
Add test for custom journal_mode in memory DB

### DIFF
--- a/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
@@ -35,9 +35,6 @@ help: the type constructed contains `fn(&_) -> Bad<'_, _> {Bad::<'_, _>::A}` due
   | |_____- this argument influences the type of `Ok`
 note: tuple variant defined here
  --> $RUST/core/src/result.rs
-  |
-  |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
-  |     ^^
   = note: this error originates in the derive macro `Codec` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use parentheses to construct this tuple variant
   |

--- a/crates/musq/tests/in_memory_settings.rs
+++ b/crates/musq/tests/in_memory_settings.rs
@@ -1,0 +1,14 @@
+use musq::{JournalMode, Musq, query_scalar};
+
+#[tokio::test]
+async fn open_in_memory_with_journal_mode_memory() -> anyhow::Result<()> {
+    let options = Musq::new().journal_mode(JournalMode::Memory);
+
+    let pool = options.open_in_memory().await?;
+    let conn = pool.acquire().await?;
+
+    let mode: String = query_scalar("PRAGMA journal_mode").fetch_one(&conn).await?;
+    assert_eq!(mode.to_uppercase(), "MEMORY");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a new test verifying `journal_mode(JournalMode::Memory)` works with `open_in_memory`
- update trybuild expected output after running with the current toolchain

## Testing
- `cargo clippy --fix --allow-dirty --tests --examples --benches`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68820914abe48333b80ab031204552cf