### PR TITLE
Add QueryBuilder empty iterator tests

### DIFF
--- a/crates/musq/tests/query_builder.rs
+++ b/crates/musq/tests/query_builder.rs
@@ -1,0 +1,21 @@
+use musq::{Error, QueryBuilder};
+
+#[test]
+fn push_values_empty_iterator_returns_error() {
+    let mut builder = QueryBuilder::new();
+    let result = builder.push_values(std::iter::empty::<i32>());
+    match result {
+        Err(Error::Protocol(msg)) => assert!(msg.contains("empty values")),
+        other => panic!("expected protocol error, got {other:?}"),
+    }
+}
+
+#[test]
+fn push_idents_empty_iterator_returns_error() {
+    let mut builder = QueryBuilder::new();
+    let result = builder.push_idents(std::iter::empty::<&str>());
+    match result {
+        Err(Error::Protocol(msg)) => assert!(msg.contains("empty idents")),
+        other => panic!("expected protocol error, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `QueryBuilder::push_values` returns a protocol error on empty iterators
- ensure `QueryBuilder::push_idents` returns a protocol error on empty iterators

## Testing
- `cargo clippy --fix --allow-dirty --tests --examples --benches`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68821416d15083338f9235aa97a8f5e5