### PR TITLE
Add dynamic values macro

### DIFF
--- a/crates/musq-macros/tests/trybuild/pass_sql_values_macro.rs
+++ b/crates/musq-macros/tests/trybuild/pass_sql_values_macro.rs
@@ -1,0 +1,10 @@
+use musq::*;
+
+fn main() -> musq::Result<()> {
+    let vals = values! { "id": 1, "name": "a" }?;
+    let _ = sql!("INSERT INTO t {insert_values:vals}")?;
+    let _ = sql!("UPDATE t SET {update_set:vals}")?;
+    let _ = sql!("SELECT * FROM t WHERE {where_and:vals}")?;
+    let _ = sql!("INSERT INTO t {insert_values:vals} ON CONFLICT(id) DO UPDATE SET {upsert_set:vals}")?;
+    Ok(())
+}

--- a/crates/musq/src/lib.rs
+++ b/crates/musq/src/lib.rs
@@ -22,6 +22,7 @@ mod query_result;
 mod row;
 mod statement_cache;
 mod transaction;
+mod values;
 #[macro_use]
 pub mod types;
 
@@ -39,4 +40,15 @@ pub use crate::{
     row::Row,
     sqlite::{Arguments, Connection, Prepared, SqliteDataType, SqliteError, Value},
     transaction::Transaction,
+    values::Values,
 };
+
+#[macro_export]
+macro_rules! values {
+    () => { ::musq::Result::<$crate::Values>::Ok($crate::Values::new()) };
+    { $($key:literal : $value:expr),* $(,)? } => {{
+        let mut _values = $crate::Values::new();
+        $( _values.insert($key, $value)?; )*
+        ::musq::Result::<$crate::Values>::Ok(_values)
+    }};
+}

--- a/crates/musq/src/values.rs
+++ b/crates/musq/src/values.rs
@@ -1,0 +1,62 @@
+use indexmap::IndexMap;
+
+use crate::{Result, Value, encode::Encode};
+
+/// An ordered collection of key-value pairs for building dynamic SQL queries.
+#[derive(Debug, Default, Clone)]
+pub struct Values(IndexMap<String, Value>);
+
+impl Values {
+    /// Creates a new, empty `Values` collection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inserts a key-value pair into the collection.
+    /// The key should be the name of the database column.
+    pub fn insert<K, V>(&mut self, key: K, value: V) -> Result<()>
+    where
+        K: Into<String>,
+        V: Encode,
+    {
+        let value = value.encode().map_err(crate::Error::Encode)?;
+        self.0.insert(key.into(), value);
+        Ok(())
+    }
+
+    /// Consumes `self`, inserts a key-value pair, and returns `Self` for
+    /// chaining.
+    pub fn val<K, V>(mut self, key: K, value: V) -> Result<Self>
+    where
+        K: Into<String>,
+        V: Encode,
+    {
+        self.insert(key, value)?;
+        Ok(self)
+    }
+
+    /// Returns `true` if the collection contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the number of elements in the collection.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Iterate over key-value pairs in insertion order.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Value)> {
+        self.0.iter()
+    }
+
+    /// Iterate over the keys in insertion order.
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.0.keys()
+    }
+
+    /// Iterate over the values in insertion order.
+    pub fn values(&self) -> impl Iterator<Item = &Value> {
+        self.0.values()
+    }
+}

--- a/crates/musq/tests/dynamic_values.rs
+++ b/crates/musq/tests/dynamic_values.rs
@@ -1,0 +1,239 @@
+use musq::{Values, sql, sql_as, values};
+use musq_test::connection;
+
+#[derive(musq::FromRow, Debug, PartialEq)]
+struct User {
+    id: i32,
+    name: String,
+    status: String,
+    last_login: String,
+}
+
+#[tokio::test]
+async fn dynamic_values_workflow() -> anyhow::Result<()> {
+    let conn = connection().await?;
+    sql!("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, status TEXT, last_login TEXT)")?
+        .execute(&conn)
+        .await?;
+
+    let data: Values =
+        values! { "id": 1, "name": "Alice", "status": "active", "last_login": "now" }?;
+    sql!("INSERT INTO users {insert_values:data}")?
+        .execute(&conn)
+        .await?;
+
+    let mut changes = Values::new();
+    changes.insert("name", "Alicia")?;
+    changes.insert("status", "inactive")?;
+    sql!("UPDATE users SET {update_set:changes} WHERE id = 1")?
+        .execute(&conn)
+        .await?;
+
+    let filters: Values = values! { "status": "inactive" }?;
+    let user: User =
+        sql_as!("SELECT id, name, status, last_login FROM users WHERE {where_and:filters}")?
+            .fetch_one(&conn)
+            .await?;
+    assert_eq!(user.name, "Alicia");
+
+    let upsert: Values =
+        values! { "id": 1, "name": "Alicia", "status": "active", "last_login": "later" }?;
+    sql!(
+        "INSERT INTO users {insert_values:upsert} ON CONFLICT(id) DO UPDATE SET {upsert_set:upsert, exclude:[\"id\"]}"
+    )?
+    .execute(&conn)
+    .await?;
+
+    let user: User = sql_as!("SELECT id, name, status, last_login FROM users WHERE id = 1")?
+        .fetch_one(&conn)
+        .await?;
+    assert_eq!(user.status, "active");
+    assert_eq!(user.last_login, "later");
+    Ok(())
+}
+
+#[tokio::test]
+async fn fluent_builder_insert() -> anyhow::Result<()> {
+    let conn = connection().await?;
+    sql!("CREATE TABLE fb (id INTEGER PRIMARY KEY, name TEXT)")?
+        .execute(&conn)
+        .await?;
+
+    let vals = Values::new().val("id", 1)?.val("name", "Bob")?;
+    sql!("INSERT INTO fb {insert_values:vals}")?
+        .execute(&conn)
+        .await?;
+
+    let row: (i32, String) = sql_as!("SELECT id, name FROM fb")?.fetch_one(&conn).await?;
+    assert_eq!(row, (1, "Bob".into()));
+    Ok(())
+}
+
+#[tokio::test]
+async fn where_and_empty_returns_all() -> anyhow::Result<()> {
+    let conn = connection().await?;
+    sql!("CREATE TABLE wa (id INTEGER)")?.execute(&conn).await?;
+    for i in 0..3 {
+        sql!("INSERT INTO wa VALUES ({})", i)?
+            .execute(&conn)
+            .await?;
+    }
+    let empty = Values::new();
+    let rows: Vec<(i32,)> = sql_as!("SELECT id FROM wa WHERE {where_and:empty}")?
+        .fetch_all(&conn)
+        .await?;
+    assert_eq!(rows.len(), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn where_and_combined_static() -> anyhow::Result<()> {
+    let conn = connection().await?;
+    sql!("CREATE TABLE wc (id INTEGER, active INTEGER)")?
+        .execute(&conn)
+        .await?;
+    for i in 0..3 {
+        let active = if i == 1 { 1 } else { 0 };
+        sql!("INSERT INTO wc VALUES ({}, {})", i, active)?
+            .execute(&conn)
+            .await?;
+    }
+    let filters: Values = values! { "id": 1 }?;
+    let rows: Vec<(i32,)> = sql_as!("SELECT id FROM wc WHERE active = 1 AND {where_and:filters}")?
+        .fetch_all(&conn)
+        .await?;
+    assert_eq!(rows, vec![(1,)]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn upsert_set_exclude_key() -> anyhow::Result<()> {
+    let conn = connection().await?;
+    sql!("CREATE TABLE us (id INTEGER PRIMARY KEY, val TEXT)")?
+        .execute(&conn)
+        .await?;
+    let vals: Values = values! { "id": 1, "val": "a" }?;
+    sql!("INSERT INTO us {insert_values:vals}")?
+        .execute(&conn)
+        .await?;
+    let new_vals: Values = values! { "id": 1, "val": "b" }?;
+    sql!(
+        "INSERT INTO us {insert_values:new_vals} \
+         ON CONFLICT(id) DO UPDATE SET {upsert_set:new_vals, exclude:[\"id\"]}"
+    )?
+    .execute(&conn)
+    .await?;
+    let row: (String,) = sql_as!("SELECT val FROM us WHERE id = 1")?
+        .fetch_one(&conn)
+        .await?;
+    assert_eq!(row.0, "b");
+    Ok(())
+}
+
+#[tokio::test]
+async fn upsert_with_subset_columns() -> anyhow::Result<()> {
+    let conn = connection().await?;
+    sql!("CREATE TABLE sub (id INTEGER PRIMARY KEY, name TEXT, logins INTEGER)")?
+        .execute(&conn)
+        .await?;
+    let initial: Values = values! { "id": 1, "name": "a", "logins": 1 }?;
+    sql!("INSERT INTO sub {insert_values:initial}")?
+        .execute(&conn)
+        .await?;
+    let up: Values = values! { "id": 1, "logins": 2 }?;
+    sql!(
+        "INSERT INTO sub {insert_values:up} \
+         ON CONFLICT(id) DO UPDATE SET {upsert_set:up, exclude:[\"id\"]}"
+    )?
+    .execute(&conn)
+    .await?;
+    let row: (String, i32) = sql_as!("SELECT name, logins FROM sub WHERE id = 1")?
+        .fetch_one(&conn)
+        .await?;
+    assert_eq!(row, ("a".into(), 2));
+    Ok(())
+}
+
+#[tokio::test]
+async fn insert_update_various_types() -> anyhow::Result<()> {
+    let conn = connection().await?;
+    sql!("CREATE TABLE ty (id INTEGER PRIMARY KEY, b INTEGER, r REAL, bl BLOB, t TEXT)")?
+        .execute(&conn)
+        .await?;
+    let vals: Values = values! {
+        "id": 1,
+        "b": true,
+        "r": 1.23_f64,
+        "bl": b"blob".as_slice(),
+        "t": Option::<String>::None,
+    }?;
+    sql!("INSERT INTO ty {insert_values:vals}")?
+        .execute(&conn)
+        .await?;
+    let upd: Values = values! { "r": 2.0, "t": Some("hi") }?;
+    sql!("UPDATE ty SET {update_set:upd} WHERE id = 1")?
+        .execute(&conn)
+        .await?;
+    let row: (bool, f64, Vec<u8>, Option<String>) =
+        sql_as!("SELECT b, r, bl, t FROM ty WHERE id = 1")?
+            .fetch_one(&conn)
+            .await?;
+    assert_eq!(row, (true, 2.0, b"blob".to_vec(), Some("hi".into())));
+    Ok(())
+}
+
+#[tokio::test]
+async fn empty_values_error() -> anyhow::Result<()> {
+    let empty = Values::new();
+    assert!(matches!(
+        sql!("INSERT INTO t {insert_values:empty}"),
+        Err(musq::Error::Protocol(_))
+    ));
+    assert!(matches!(
+        sql!("UPDATE t SET {update_set:empty}"),
+        Err(musq::Error::Protocol(_))
+    ));
+    Ok(())
+}
+
+struct Bad;
+impl musq::encode::Encode for Bad {
+    fn encode(self) -> std::result::Result<musq::Value, musq::error::EncodeError> {
+        Err(musq::error::EncodeError::Conversion("bad".into()))
+    }
+}
+
+#[tokio::test]
+async fn values_macro_encode_error() -> anyhow::Result<()> {
+    let res: musq::Result<Values> = (|| {
+        values! { "b": Bad }
+    })();
+    assert!(res.is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn macro_combination() -> anyhow::Result<()> {
+    let conn = connection().await?;
+    sql!("CREATE TABLE mix (id INTEGER PRIMARY KEY, name TEXT)")?
+        .execute(&conn)
+        .await?;
+    let table = "mix";
+    let vals: Values = values! { "id": 5, "name": "Old" }?;
+    sql!("INSERT INTO {ident:table} {insert_values:vals}")?
+        .execute(&conn)
+        .await?;
+    let changes: Values = values! { "name": "New" }?;
+    let id = 5;
+    sql!(
+        "UPDATE {ident:table} SET {update_set:changes} WHERE id = {}",
+        id
+    )?
+    .execute(&conn)
+    .await?;
+    let row: (String,) = sql_as!("SELECT name FROM mix WHERE id = 5")?
+        .fetch_one(&conn)
+        .await?;
+    assert_eq!(row.0, "New");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support dynamic key/value collections with new `Values` struct
- implement `values!` macro for easier creation
- extend `QueryBuilder` for insert/update/where/upsert helpers with exclusions
- refactor SQL macro expansion and update placeholders
- add fluent builder API and broad integration tests
- fix UPSERT builder when exclusions remove all columns

## Testing
- `cargo clippy --fix --allow-dirty --tests --examples --benches -q`
- `cargo test --color=never -q`
- `TRYBUILD=overwrite cargo test -p musq-macros --test derive --color=never -q`


------
https://chatgpt.com/codex/tasks/task_e_6882418c4aa083338cdf0802ff5da6d2