### PR TITLE
Update placeholder syntax

### DIFF
--- a/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
@@ -35,9 +35,6 @@ help: the type constructed contains `fn(&_) -> Bad<'_, _> {Bad::<'_, _>::A}` due
   | |_____- this argument influences the type of `Ok`
 note: tuple variant defined here
  --> $RUST/core/src/result.rs
-  |
-  |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
-  |     ^^
   = note: this error originates in the derive macro `Codec` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use parentheses to construct this tuple variant
   |

--- a/crates/musq-macros/tests/trybuild/pass_sql_values_macro.rs
+++ b/crates/musq-macros/tests/trybuild/pass_sql_values_macro.rs
@@ -2,9 +2,9 @@ use musq::*;
 
 fn main() -> musq::Result<()> {
     let vals = values! { "id": 1, "name": "a" }?;
-    let _ = sql!("INSERT INTO t {insert_values:vals}")?;
-    let _ = sql!("UPDATE t SET {update_set:vals}")?;
-    let _ = sql!("SELECT * FROM t WHERE {where_and:vals}")?;
-    let _ = sql!("INSERT INTO t {insert_values:vals} ON CONFLICT(id) DO UPDATE SET {upsert_set:vals}")?;
+    let _ = sql!("INSERT INTO t {insert:vals}")?;
+    let _ = sql!("UPDATE t SET {set:vals}")?;
+    let _ = sql!("SELECT * FROM t WHERE {where:vals}")?;
+    let _ = sql!("INSERT INTO t {insert:vals} ON CONFLICT(id) DO UPDATE SET {upsert:vals}")?;
     Ok(())
 }

--- a/crates/musq/src/query_builder.rs
+++ b/crates/musq/src/query_builder.rs
@@ -82,7 +82,7 @@ impl QueryBuilder {
         Ok(())
     }
 
-    pub fn push_insert_values(&mut self, values: &crate::Values) -> Result<()> {
+    pub fn push_insert(&mut self, values: &crate::Values) -> Result<()> {
         if values.is_empty() {
             return Err(crate::Error::Protocol("empty values".into()));
         }
@@ -109,7 +109,7 @@ impl QueryBuilder {
         Ok(())
     }
 
-    pub fn push_update_set(&mut self, values: &crate::Values) -> Result<()> {
+    pub fn push_set(&mut self, values: &crate::Values) -> Result<()> {
         if values.is_empty() {
             return Err(crate::Error::Protocol("empty values".into()));
         }
@@ -126,7 +126,7 @@ impl QueryBuilder {
         Ok(())
     }
 
-    pub fn push_where_and(&mut self, values: &crate::Values) -> Result<()> {
+    pub fn push_where(&mut self, values: &crate::Values) -> Result<()> {
         if values.is_empty() {
             self.sql.push_str("1=1");
             return Ok(());
@@ -144,7 +144,7 @@ impl QueryBuilder {
         Ok(())
     }
 
-    pub fn push_upsert_set(&mut self, values: &crate::Values, exclude: &[&str]) -> Result<()> {
+    pub fn push_upsert(&mut self, values: &crate::Values, exclude: &[&str]) -> Result<()> {
         if values.is_empty() {
             return Err(crate::Error::Protocol("empty values".into()));
         }


### PR DESCRIPTION
## Summary
- rename value expansion placeholders (insert, set, where, upsert)
- update QueryBuilder methods for new names
- adjust macro parsing and tests
- document the changes and show upsert usage

## Testing
- `cargo clippy --fix --allow-dirty --tests --examples --benches`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6884219ff0b88333abc3f5adb596210f