### PR TITLE
failing test

### DIFF
--- a/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
+++ b/crates/musq-macros/tests/trybuild/fail_codec_enum.stderr
@@ -12,34 +12,34 @@ error[E0532]: expected unit struct, unit variant or constant, found tuple varian
 error[E0308]: mismatched types
  --> tests/trybuild/fail_codec_enum.rs:4:6
   |
-3 |   #[derive(Codec)]
-  |            ----- arguments to this enum variant are incorrect
-4 |   enum Bad<'a, T> {
-  |  ______^
-5 | |     A(&'a T),
-  | |     ^
-  | |     |
-  | |_____`A` defines an enum variant constructor here, which should be called
-  |       expected `Bad<'_, T>`, found enum constructor
-  |
-  = note:          expected enum `Bad<'_, T>`
-          found enum constructor `fn(&_) -> Bad<'_, _> {Bad::<'_, _>::A}`
+  3 |   #[derive(Codec)]
+    |            ----- arguments to this enum variant are incorrect
+  4 |   enum Bad<'a, T> {
+    |  ______^
+  5 | |     A(&'a T),
+    | |     ^
+    | |     |
+    | |_____`A` defines an enum variant constructor here, which should be called
+    |       expected `Bad<'_, T>`, found enum constructor
+    |
+    = note:          expected enum `Bad<'_, T>`
+            found enum constructor `fn(&_) -> Bad<'_, _> {Bad::<'_, _>::A}`
 help: the type constructed contains `fn(&_) -> Bad<'_, _> {Bad::<'_, _>::A}` due to the type of the argument passed
- --> tests/trybuild/fail_codec_enum.rs:3:10
-  |
-3 |   #[derive(Codec)]
-  |            ^^^^^
-4 |   enum Bad<'a, T> {
-  |  ______-
-5 | |     A(&'a T),
-  | |_____- this argument influences the type of `Ok`
+   --> tests/trybuild/fail_codec_enum.rs:3:10
+    |
+  3 |   #[derive(Codec)]
+    |            ^^^^^
+  4 |   enum Bad<'a, T> {
+    |  ______-
+  5 | |     A(&'a T),
+    | |_____- this argument influences the type of `Ok`
 note: tuple variant defined here
- --> $RUST/core/src/result.rs
-  |
-  |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
-  |     ^^
-  = note: this error originates in the derive macro `Codec` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $RUST/core/src/result.rs
+    |
+    |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+    |     ^^
+    = note: this error originates in the derive macro `Codec` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use parentheses to construct this tuple variant
-  |
-5 |     A(/* value */)(&'a T),
-  |      +++++++++++++
+    |
+  5 |     A(/* value */)(&'a T),
+    |      +++++++++++++

--- a/crates/musq/src/encode.rs
+++ b/crates/musq/src/encode.rs
@@ -156,6 +156,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_option_some_f64() {
         let opt: Option<f64> = Some(3.14);
         let encoded = opt.encode().unwrap();
@@ -268,7 +269,7 @@ mod tests {
 
     #[test]
     fn test_null_reference() {
-        let encoded = (&Null).encode().unwrap();
+        let encoded = Null.encode().unwrap();
 
         if let Value::Null { type_info } = encoded {
             assert_eq!(type_info, None);

--- a/crates/musq/src/types/bool.rs
+++ b/crates/musq/src/types/bool.rs
@@ -34,7 +34,7 @@ mod tests {
     #[test]
     fn test_reference_encode() {
         let value = true;
-        let result = (&value).encode().unwrap();
+        let result = value.encode().unwrap();
         if let Value::Integer { value: encoded, .. } = result {
             assert_eq!(encoded, 1);
         } else {
@@ -42,7 +42,7 @@ mod tests {
         }
 
         let value_false = false;
-        let result = (&value_false).encode().unwrap();
+        let result = value_false.encode().unwrap();
         if let Value::Integer { value: encoded, .. } = result {
             assert_eq!(encoded, 0);
         } else {

--- a/crates/musq/src/types/float.rs
+++ b/crates/musq/src/types/float.rs
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn test_reference_encode() {
         let value = std::f32::consts::PI;
-        let result = (&value).encode().unwrap();
+        let result = value.encode().unwrap();
         if let Value::Double { value: encoded, .. } = result {
             assert!((encoded - value as f64).abs() < 1e-6);
         } else {
@@ -52,7 +52,7 @@ mod tests {
         }
 
         let value_f64 = std::f64::consts::E;
-        let result = (&value_f64).encode().unwrap();
+        let result = value_f64.encode().unwrap();
         if let Value::Double { value: encoded, .. } = result {
             assert!((encoded - std::f64::consts::E).abs() < f64::EPSILON);
         } else {

--- a/crates/musq/src/types/int.rs
+++ b/crates/musq/src/types/int.rs
@@ -90,7 +90,7 @@ mod tests {
     #[test]
     fn test_reference_encode() {
         let value = 42i32;
-        let result = (&value).encode().unwrap();
+        let result = value.encode().unwrap();
         if let Value::Integer { value: encoded, .. } = result {
             assert_eq!(encoded, 42);
         } else {
@@ -98,7 +98,7 @@ mod tests {
         }
 
         let value_i8 = 127i8;
-        let result = (&value_i8).encode().unwrap();
+        let result = value_i8.encode().unwrap();
         if let Value::Integer { value: encoded, .. } = result {
             assert_eq!(encoded, 127);
         } else {
@@ -106,7 +106,7 @@ mod tests {
         }
 
         let value_u32 = 123u32;
-        let result = (&value_u32).encode().unwrap();
+        let result = value_u32.encode().unwrap();
         if let Value::Integer { value: encoded, .. } = result {
             assert_eq!(encoded, 123);
         } else {

--- a/crates/musq/src/types/str.rs
+++ b/crates/musq/src/types/str.rs
@@ -71,7 +71,7 @@ mod tests {
     #[test]
     fn test_string_reference_encode() {
         let value = String::from("hello");
-        let result = (&value).encode().unwrap();
+        let result = value.encode().unwrap();
         if let Value::Text { value: encoded, .. } = result {
             assert_eq!(encoded, "hello");
         } else {


### PR DESCRIPTION
{set:something} macro fails when followed by named param. This is repro for this